### PR TITLE
Add platform adapters for Claude Code, Codex CLI, and OpenCode (M3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,7 @@ Names must match `^[a-z0-9]+(-[a-z0-9]+)*$` and be 1-64 characters.
 
 ## Current Status
 
-The project has completed **M2 — Skill Validation & Overlap Detection**. See `PLAN.md` for the full roadmap with milestones M0 through M6.
+The project has completed **M3 — Platform Adapters** (Claude Code, Codex CLI, OpenCode). See `PLAN.md` for the full roadmap with milestones M0 through M6.
 
 <!-- br-agent-instructions-v1 -->
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ scribe skill validate my-skill
 # Install a skill to a platform
 scribe skill install my-skill --platform claude-code
 
+# Install to all detected platforms at once
+scribe skill install my-skill --platform all
+
+# Uninstall a skill from a platform
+scribe skill uninstall my-skill --platform claude-code
+
+# List detected platforms
+scribe platform list
+
+# Show skill installation status across platforms
+scribe platform status
+
 # Search for existing skills
 scribe skill search "code review"
 ```
@@ -79,6 +91,10 @@ scribe version                                 # Print version info
 **Global flags:** `--json`, `--quiet`, `--scope user|project`
 
 **`skill create` flags:** `--author`, `--author-type human|agent`, `--author-platform`, `--description`, `--force` (bypass overlap block)
+
+**`skill install/uninstall` flags:** `--platform claude-code|codex-cli|opencode|all` (required), `--scope user|project`
+
+**`platform status` flags:** `--scope user|project`
 
 ### Validation
 

--- a/internal/cli/platform.go
+++ b/internal/cli/platform.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newPlatformCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "platform",
+		Short: "Manage platform adapters",
+		Long:  "List detected platforms and check skill installation status across platforms.",
+	}
+
+	cmd.AddCommand(newPlatformListCmd())
+	cmd.AddCommand(newPlatformStatusCmd())
+
+	return cmd
+}

--- a/internal/cli/platform_list.go
+++ b/internal/cli/platform_list.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/devrimcavusoglu/scribe/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newPlatformListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List known platforms and their detection status",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			det, err := newDetectorFunc()
+			if err != nil {
+				return err
+			}
+
+			all := det.All()
+			var platforms []output.PlatformResult
+			for _, p := range all {
+				platforms = append(platforms, output.PlatformResult{
+					Name:        string(p.Name()),
+					Detected:    p.Detect(),
+					UserPath:    p.UserSkillsDir(),
+					ProjectPath: p.ProjectSkillsDir(),
+				})
+			}
+
+			result := output.PlatformListResult{
+				Platforms: platforms,
+				Count:     len(platforms),
+			}
+
+			text := formatPlatformList(platforms)
+			printer.PrintResult(result, text)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func formatPlatformList(platforms []output.PlatformResult) string {
+	if len(platforms) == 0 {
+		return "No platforms registered.\n"
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%-15s %-10s %-40s %s\n", "PLATFORM", "DETECTED", "USER PATH", "PROJECT PATH"))
+	for _, p := range platforms {
+		detected := "no"
+		if p.Detected {
+			detected = "yes"
+		}
+		b.WriteString(fmt.Sprintf("%-15s %-10s %-40s %s\n", p.Name, detected, p.UserPath, p.ProjectPath))
+	}
+	return b.String()
+}

--- a/internal/cli/platform_status.go
+++ b/internal/cli/platform_status.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/devrimcavusoglu/scribe/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func newPlatformStatusCmd() *cobra.Command {
+	var scope string
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show skill installation status across platforms",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			scopeVal, err := parseScope(scope)
+			if err != nil {
+				return err
+			}
+
+			reg, err := newRegistryFunc()
+			if err != nil {
+				return err
+			}
+
+			det, err := newDetectorFunc()
+			if err != nil {
+				return err
+			}
+
+			// Get skills from registry
+			skills, err := reg.List(scopeVal)
+			if err != nil {
+				return fmt.Errorf("listing skills: %w", err)
+			}
+
+			detected := det.DetectAll()
+
+			// Build installed skills index per platform
+			type platformSkills struct {
+				name      string
+				installed map[string]bool
+			}
+			var platformIndex []platformSkills
+			for _, p := range detected {
+				names, listErr := p.InstalledSkills(scopeVal)
+				if listErr != nil {
+					continue
+				}
+				installed := make(map[string]bool)
+				for _, n := range names {
+					installed[n] = true
+				}
+				platformIndex = append(platformIndex, platformSkills{
+					name:      string(p.Name()),
+					installed: installed,
+				})
+			}
+
+			// Build status entries
+			var entries []output.PlatformStatusEntry
+			for _, s := range skills {
+				entry := output.PlatformStatusEntry{
+					Skill: s.Name,
+				}
+				for _, pi := range platformIndex {
+					entry.Platforms = append(entry.Platforms, output.PlatformInstallStatus{
+						Platform:  pi.name,
+						Installed: pi.installed[s.Name],
+					})
+				}
+				entries = append(entries, entry)
+			}
+
+			result := output.PlatformStatusResult{
+				Scope:  scope,
+				Status: entries,
+			}
+
+			text := formatPlatformStatus(scope, entries)
+			printer.PrintResult(result, text)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&scope, "scope", "user", "skill scope (user or project)")
+
+	return cmd
+}
+
+func formatPlatformStatus(scope string, entries []output.PlatformStatusEntry) string {
+	if len(entries) == 0 {
+		return fmt.Sprintf("No skills in %s scope.\n", scope)
+	}
+
+	// Collect platform names from the first entry
+	var platformNames []string
+	if len(entries[0].Platforms) > 0 {
+		for _, p := range entries[0].Platforms {
+			platformNames = append(platformNames, p.Platform)
+		}
+	}
+
+	if len(platformNames) == 0 {
+		return fmt.Sprintf("No platforms detected. Skills in %s scope: %d\n", scope, len(entries))
+	}
+
+	var b strings.Builder
+	// Header
+	b.WriteString(fmt.Sprintf("%-30s", "SKILL"))
+	for _, name := range platformNames {
+		b.WriteString(fmt.Sprintf(" %-15s", name))
+	}
+	b.WriteString("\n")
+
+	// Rows
+	for _, entry := range entries {
+		b.WriteString(fmt.Sprintf("%-30s", entry.Skill))
+		for _, p := range entry.Platforms {
+			status := "-"
+			if p.Installed {
+				status = "installed"
+			}
+			b.WriteString(fmt.Sprintf(" %-15s", status))
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/internal/cli/platform_test.go
+++ b/internal/cli/platform_test.go
@@ -1,0 +1,395 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devrimcavusoglu/scribe/internal/output"
+	"github.com/devrimcavusoglu/scribe/internal/platform"
+	"github.com/devrimcavusoglu/scribe/internal/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestDetector overrides newDetectorFunc to use temp directories with all platforms detected.
+func setupTestDetector(t *testing.T, home, project string) {
+	t.Helper()
+
+	// Create platform directories so they are detected
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".agents"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "opencode"), 0o755))
+
+	original := newDetectorFunc
+	newDetectorFunc = func() (*platform.Detector, error) {
+		return platform.NewDetectorWithPlatforms([]platform.Platform{
+			platform.NewClaudeCode(home, project),
+			platform.NewCodexCLI(home, project),
+			platform.NewOpenCode(home, project),
+		}), nil
+	}
+	t.Cleanup(func() { newDetectorFunc = original })
+}
+
+// setupTestRegistryWithDirs overrides newRegistryFunc and returns the dirs used.
+func setupTestRegistryWithDirs(t *testing.T) (userDir, projectDir string) {
+	t.Helper()
+	userDir = filepath.Join(t.TempDir(), "user-skills")
+	projectDir = filepath.Join(t.TempDir(), "project-skills")
+
+	original := newRegistryFunc
+	newRegistryFunc = func() (*registry.Registry, error) {
+		return registry.New(userDir, projectDir), nil
+	}
+	t.Cleanup(func() { newRegistryFunc = original })
+	return userDir, projectDir
+}
+
+// --- skill install ---
+
+func TestSkillInstall(t *testing.T) {
+	userDir, _ := setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	// Create a skill first
+	_, err := runCmd(t, "skill", "create", "install-me", "--description", "A test skill")
+	require.NoError(t, err)
+
+	// Install to claude-code
+	out, err := runCmd(t, "skill", "install", "install-me", "--platform", "claude-code", "--json")
+	require.NoError(t, err)
+
+	var result output.SkillInstallResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, "install-me", result.Skill)
+	assert.Len(t, result.Platforms, 1)
+	assert.True(t, result.Platforms[0].Success)
+	assert.Equal(t, "claude-code", result.Platforms[0].Platform)
+
+	// Verify file exists
+	installed := filepath.Join(home, ".claude", "skills", "install-me", "SKILL.md")
+	_, err = os.Stat(installed)
+	require.NoError(t, err)
+
+	// Verify it's a copy of the registry skill
+	registrySKILL := filepath.Join(userDir, "install-me", "SKILL.md")
+	regContent, err := os.ReadFile(registrySKILL)
+	require.NoError(t, err)
+	installedContent, err := os.ReadFile(installed)
+	require.NoError(t, err)
+	assert.Equal(t, string(regContent), string(installedContent))
+}
+
+func TestSkillInstall_Text(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	_, err := runCmd(t, "skill", "create", "text-install", "--description", "Test")
+	require.NoError(t, err)
+
+	out, err := runCmd(t, "skill", "install", "text-install", "--platform", "claude-code")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Installed")
+	assert.Contains(t, out, "text-install")
+	assert.Contains(t, out, "claude-code")
+}
+
+func TestSkillInstall_AllPlatforms(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	_, err := runCmd(t, "skill", "create", "all-platforms", "--description", "Test")
+	require.NoError(t, err)
+
+	out, err := runCmd(t, "skill", "install", "all-platforms", "--platform", "all", "--json")
+	require.NoError(t, err)
+
+	var result output.SkillInstallResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, "all-platforms", result.Skill)
+	assert.Len(t, result.Platforms, 3)
+	for _, p := range result.Platforms {
+		assert.True(t, p.Success, "expected success for %s", p.Platform)
+	}
+}
+
+func TestSkillInstall_Duplicate(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	_, err := runCmd(t, "skill", "create", "dup-install", "--description", "Test")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, "skill", "install", "dup-install", "--platform", "claude-code")
+	require.NoError(t, err)
+
+	// Second install should fail
+	_, err = runCmd(t, "skill", "install", "dup-install", "--platform", "claude-code")
+	assert.Error(t, err)
+}
+
+func TestSkillInstall_NotFound(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	_, err := runCmd(t, "skill", "install", "nonexistent", "--platform", "claude-code")
+	assert.Error(t, err)
+}
+
+func TestSkillInstall_InvalidPlatform(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	_, err := runCmd(t, "skill", "create", "my-skill", "--description", "Test")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, "skill", "install", "my-skill", "--platform", "invalid")
+	assert.Error(t, err)
+}
+
+func TestSkillInstall_MissingPlatformFlag(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	_, err := runCmd(t, "skill", "install", "my-skill")
+	assert.Error(t, err)
+}
+
+func TestSkillInstall_InvalidName(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	_, err := runCmd(t, "skill", "install", "INVALID", "--platform", "claude-code")
+	assert.Error(t, err)
+}
+
+// --- skill uninstall ---
+
+func TestSkillUninstall(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	_, err := runCmd(t, "skill", "create", "remove-platform", "--description", "Test")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, "skill", "install", "remove-platform", "--platform", "claude-code")
+	require.NoError(t, err)
+
+	out, err := runCmd(t, "skill", "uninstall", "remove-platform", "--platform", "claude-code", "--json")
+	require.NoError(t, err)
+
+	var result output.SkillUninstallResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, "remove-platform", result.Skill)
+	assert.Len(t, result.Platforms, 1)
+	assert.True(t, result.Platforms[0].Success)
+
+	// Verify removed
+	installed := filepath.Join(home, ".claude", "skills", "remove-platform")
+	_, err = os.Stat(installed)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestSkillUninstall_Text(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	_, err := runCmd(t, "skill", "create", "text-uninstall", "--description", "Test")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, "skill", "install", "text-uninstall", "--platform", "claude-code")
+	require.NoError(t, err)
+
+	out, err := runCmd(t, "skill", "uninstall", "text-uninstall", "--platform", "claude-code")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Uninstalled")
+	assert.Contains(t, out, "text-uninstall")
+}
+
+func TestSkillUninstall_NotInstalled(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	_, err := runCmd(t, "skill", "uninstall", "nonexistent", "--platform", "claude-code")
+	assert.Error(t, err)
+}
+
+// --- platform list ---
+
+func TestPlatformList(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	out, err := runCmd(t, "platform", "list", "--json")
+	require.NoError(t, err)
+
+	var result output.PlatformListResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, 3, result.Count)
+
+	// All should be detected since setupTestDetector creates the directories
+	for _, p := range result.Platforms {
+		assert.True(t, p.Detected, "expected %s to be detected", p.Name)
+	}
+}
+
+func TestPlatformList_Text(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	out, err := runCmd(t, "platform", "list")
+	require.NoError(t, err)
+	assert.Contains(t, out, "claude-code")
+	assert.Contains(t, out, "codex-cli")
+	assert.Contains(t, out, "opencode")
+	assert.Contains(t, out, "yes")
+}
+
+func TestPlatformList_PartialDetection(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+
+	// Only create .claude directory
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
+
+	original := newDetectorFunc
+	newDetectorFunc = func() (*platform.Detector, error) {
+		return platform.NewDetectorWithPlatforms([]platform.Platform{
+			platform.NewClaudeCode(home, project),
+			platform.NewCodexCLI(home, project),
+			platform.NewOpenCode(home, project),
+		}), nil
+	}
+	t.Cleanup(func() { newDetectorFunc = original })
+
+	out, err := runCmd(t, "platform", "list", "--json")
+	require.NoError(t, err)
+
+	var result output.PlatformListResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+
+	detectedCount := 0
+	for _, p := range result.Platforms {
+		if p.Detected {
+			detectedCount++
+			assert.Equal(t, "claude-code", p.Name)
+		}
+	}
+	assert.Equal(t, 1, detectedCount)
+}
+
+// --- platform status ---
+
+func TestPlatformStatus_Empty(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	out, err := runCmd(t, "platform", "status", "--json")
+	require.NoError(t, err)
+
+	var result output.PlatformStatusResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, "user", result.Scope)
+	assert.Empty(t, result.Status)
+}
+
+func TestPlatformStatus_WithSkills(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	// Create and install a skill
+	_, err := runCmd(t, "skill", "create", "status-skill", "--description", "Test")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, "skill", "install", "status-skill", "--platform", "claude-code")
+	require.NoError(t, err)
+
+	out, err := runCmd(t, "platform", "status", "--json")
+	require.NoError(t, err)
+
+	var result output.PlatformStatusResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Len(t, result.Status, 1)
+	assert.Equal(t, "status-skill", result.Status[0].Skill)
+
+	// Find claude-code entry
+	var found bool
+	for _, p := range result.Status[0].Platforms {
+		if p.Platform == "claude-code" {
+			assert.True(t, p.Installed)
+			found = true
+		}
+	}
+	assert.True(t, found, "expected claude-code entry in platforms")
+}
+
+func TestPlatformStatus_Text(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	_, err := runCmd(t, "skill", "create", "text-status", "--description", "Test")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, "skill", "install", "text-status", "--platform", "claude-code")
+	require.NoError(t, err)
+
+	out, err := runCmd(t, "platform", "status")
+	require.NoError(t, err)
+	assert.Contains(t, out, "text-status")
+	assert.Contains(t, out, "installed")
+}
+
+func TestPlatformStatus_ProjectScope(t *testing.T) {
+	setupTestRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	setupTestDetector(t, home, project)
+
+	// Create skill in project scope
+	_, err := runCmd(t, "skill", "create", "proj-status", "--scope", "project", "--description", "Test")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, "skill", "install", "proj-status", "--platform", "claude-code", "--scope", "project")
+	require.NoError(t, err)
+
+	out, err := runCmd(t, "platform", "status", "--scope", "project", "--json")
+	require.NoError(t, err)
+
+	var result output.PlatformStatusResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, "project", result.Scope)
+	assert.Len(t, result.Status, 1)
+	assert.Equal(t, "proj-status", result.Status[0].Skill)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -34,6 +34,7 @@ func NewRootCmd() *cobra.Command {
 
 	cmd.AddCommand(newVersionCmd())
 	cmd.AddCommand(newSkillCmd())
+	cmd.AddCommand(newPlatformCmd())
 
 	return cmd
 }

--- a/internal/cli/skill.go
+++ b/internal/cli/skill.go
@@ -17,6 +17,8 @@ func newSkillCmd() *cobra.Command {
 	cmd.AddCommand(newSkillSearchCmd())
 	cmd.AddCommand(newSkillValidateCmd())
 	cmd.AddCommand(newSkillRemoveCmd())
+	cmd.AddCommand(newSkillInstallCmd())
+	cmd.AddCommand(newSkillUninstallCmd())
 
 	return cmd
 }

--- a/internal/cli/skill_helpers.go
+++ b/internal/cli/skill_helpers.go
@@ -7,12 +7,16 @@ import (
 	"strings"
 
 	"github.com/devrimcavusoglu/scribe/internal/output"
+	"github.com/devrimcavusoglu/scribe/internal/platform"
 	"github.com/devrimcavusoglu/scribe/internal/registry"
 	"github.com/devrimcavusoglu/scribe/internal/skill"
 )
 
 // newRegistryFunc creates a Registry. Overridable in tests.
 var newRegistryFunc = defaultNewRegistry
+
+// newDetectorFunc creates a platform Detector. Overridable in tests.
+var newDetectorFunc = defaultNewDetector
 
 func defaultNewRegistry() (*registry.Registry, error) {
 	home, err := os.UserHomeDir()
@@ -24,6 +28,10 @@ func defaultNewRegistry() (*registry.Registry, error) {
 	projectDir := filepath.Join(".", ".scribe", "skills")
 
 	return registry.New(userDir, projectDir), nil
+}
+
+func defaultNewDetector() (*platform.Detector, error) {
+	return platform.NewDetector()
 }
 
 // parseScope converts a scope string flag to a skill.Scope.

--- a/internal/cli/skill_install.go
+++ b/internal/cli/skill_install.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/devrimcavusoglu/scribe/internal/output"
+	"github.com/devrimcavusoglu/scribe/internal/platform"
+	"github.com/devrimcavusoglu/scribe/internal/skill"
+	"github.com/spf13/cobra"
+)
+
+func newSkillInstallCmd() *cobra.Command {
+	var (
+		platformFlag string
+		scope        string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "install <name>",
+		Short: "Install a skill to a platform",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			if err := skill.ValidateName(name); err != nil {
+				return &ValidationError{Message: err.Error()}
+			}
+
+			platformType, err := platform.ParsePlatformType(platformFlag)
+			if err != nil {
+				return &ValidationError{Message: err.Error()}
+			}
+
+			scopeVal, err := parseScope(scope)
+			if err != nil {
+				return err
+			}
+
+			reg, err := newRegistryFunc()
+			if err != nil {
+				return err
+			}
+
+			// Resolve skill from registry
+			s, skillDir, err := reg.Get(name, scopeVal)
+			if err != nil {
+				return fmt.Errorf("skill %q not found in %s scope: %w", name, scope, err)
+			}
+			_ = s // skill metadata not needed for install
+
+			det, err := newDetectorFunc()
+			if err != nil {
+				return err
+			}
+
+			// Determine target platforms
+			var targets []platform.Platform
+			if platformType == platform.Type("all") {
+				targets = det.DetectAll()
+				if len(targets) == 0 {
+					return fmt.Errorf("no platforms detected; install a supported platform first")
+				}
+			} else {
+				p := det.Get(platformType)
+				if p == nil {
+					return fmt.Errorf("platform %q not registered", platformFlag)
+				}
+				targets = []platform.Platform{p}
+			}
+
+			// Install to each target platform
+			var entries []output.PlatformInstallEntry
+			var successCount int
+			for _, p := range targets {
+				entry := output.PlatformInstallEntry{
+					Platform: string(p.Name()),
+				}
+				if installErr := p.Install(skillDir, name, scopeVal); installErr != nil {
+					entry.Error = installErr.Error()
+				} else {
+					entry.Success = true
+					successCount++
+				}
+				entries = append(entries, entry)
+			}
+
+			result := output.SkillInstallResult{
+				Skill:     name,
+				Scope:     scope,
+				Platforms: entries,
+			}
+
+			text := formatInstallResult(name, entries)
+			printer.PrintResult(result, text)
+
+			if successCount == 0 {
+				return fmt.Errorf("failed to install %q to any platform", name)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&platformFlag, "platform", "", "target platform (claude-code, codex-cli, opencode, or all)")
+	cmd.Flags().StringVar(&scope, "scope", "user", "skill scope (user or project)")
+	_ = cmd.MarkFlagRequired("platform")
+
+	return cmd
+}
+
+func formatInstallResult(name string, entries []output.PlatformInstallEntry) string {
+	var b strings.Builder
+	for _, e := range entries {
+		if e.Success {
+			b.WriteString(fmt.Sprintf("Installed %q to %s\n", name, e.Platform))
+		} else {
+			b.WriteString(fmt.Sprintf("Failed to install %q to %s: %s\n", name, e.Platform, e.Error))
+		}
+	}
+	return b.String()
+}

--- a/internal/cli/skill_uninstall.go
+++ b/internal/cli/skill_uninstall.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/devrimcavusoglu/scribe/internal/output"
+	"github.com/devrimcavusoglu/scribe/internal/platform"
+	"github.com/devrimcavusoglu/scribe/internal/skill"
+	"github.com/spf13/cobra"
+)
+
+func newSkillUninstallCmd() *cobra.Command {
+	var (
+		platformFlag string
+		scope        string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "uninstall <name>",
+		Short: "Uninstall a skill from a platform",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			if err := skill.ValidateName(name); err != nil {
+				return &ValidationError{Message: err.Error()}
+			}
+
+			platformType, err := platform.ParsePlatformType(platformFlag)
+			if err != nil {
+				return &ValidationError{Message: err.Error()}
+			}
+
+			scopeVal, err := parseScope(scope)
+			if err != nil {
+				return err
+			}
+
+			det, err := newDetectorFunc()
+			if err != nil {
+				return err
+			}
+
+			// Determine target platforms
+			var targets []platform.Platform
+			if platformType == platform.Type("all") {
+				targets = det.DetectAll()
+				if len(targets) == 0 {
+					return fmt.Errorf("no platforms detected; install a supported platform first")
+				}
+			} else {
+				p := det.Get(platformType)
+				if p == nil {
+					return fmt.Errorf("platform %q not registered", platformFlag)
+				}
+				targets = []platform.Platform{p}
+			}
+
+			// Uninstall from each target platform
+			var entries []output.PlatformUninstallEntry
+			var successCount int
+			for _, p := range targets {
+				entry := output.PlatformUninstallEntry{
+					Platform: string(p.Name()),
+				}
+				if uninstallErr := p.Uninstall(name, scopeVal); uninstallErr != nil {
+					entry.Error = uninstallErr.Error()
+				} else {
+					entry.Success = true
+					successCount++
+				}
+				entries = append(entries, entry)
+			}
+
+			result := output.SkillUninstallResult{
+				Skill:     name,
+				Scope:     string(scopeVal),
+				Platforms: entries,
+			}
+
+			text := formatUninstallResult(name, entries)
+			printer.PrintResult(result, text)
+
+			if successCount == 0 {
+				return fmt.Errorf("failed to uninstall %q from any platform", name)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&platformFlag, "platform", "", "target platform (claude-code, codex-cli, opencode, or all)")
+	cmd.Flags().StringVar(&scope, "scope", "user", "skill scope (user or project)")
+	_ = cmd.MarkFlagRequired("platform")
+
+	return cmd
+}
+
+func formatUninstallResult(name string, entries []output.PlatformUninstallEntry) string {
+	var b strings.Builder
+	for _, e := range entries {
+		if e.Success {
+			b.WriteString(fmt.Sprintf("Uninstalled %q from %s\n", name, e.Platform))
+		} else {
+			b.WriteString(fmt.Sprintf("Failed to uninstall %q from %s: %s\n", name, e.Platform, e.Error))
+		}
+	}
+	return b.String()
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -186,3 +186,63 @@ type OverlapCheckResult struct {
 	Matches  []OverlapResult `json:"matches"`
 	MaxScore float64         `json:"max_score"`
 }
+
+// PlatformInstallEntry records the result of installing a skill to one platform.
+type PlatformInstallEntry struct {
+	Platform string `json:"platform"`
+	Success  bool   `json:"success"`
+	Error    string `json:"error,omitempty"`
+}
+
+// SkillInstallResult is the JSON envelope for skill install output.
+type SkillInstallResult struct {
+	Skill     string                 `json:"skill"`
+	Scope     string                 `json:"scope"`
+	Platforms []PlatformInstallEntry `json:"platforms"`
+}
+
+// PlatformUninstallEntry records the result of uninstalling a skill from one platform.
+type PlatformUninstallEntry struct {
+	Platform string `json:"platform"`
+	Success  bool   `json:"success"`
+	Error    string `json:"error,omitempty"`
+}
+
+// SkillUninstallResult is the JSON envelope for skill uninstall output.
+type SkillUninstallResult struct {
+	Skill     string                   `json:"skill"`
+	Scope     string                   `json:"scope"`
+	Platforms []PlatformUninstallEntry `json:"platforms"`
+}
+
+// PlatformResult represents a single detected platform.
+type PlatformResult struct {
+	Name        string `json:"name"`
+	Detected    bool   `json:"detected"`
+	UserPath    string `json:"user_path"`
+	ProjectPath string `json:"project_path"`
+}
+
+// PlatformListResult is the JSON envelope for platform list output.
+type PlatformListResult struct {
+	Platforms []PlatformResult `json:"platforms"`
+	Count     int              `json:"count"`
+}
+
+// PlatformInstallStatus shows whether a skill is installed on a platform.
+type PlatformInstallStatus struct {
+	Platform  string `json:"platform"`
+	Installed bool   `json:"installed"`
+}
+
+// PlatformStatusEntry shows install status for one skill across platforms.
+type PlatformStatusEntry struct {
+	Skill     string                  `json:"skill"`
+	Platforms []PlatformInstallStatus `json:"platforms"`
+}
+
+// PlatformStatusResult is the JSON envelope for platform status output.
+type PlatformStatusResult struct {
+	Scope  string                `json:"scope"`
+	Status []PlatformStatusEntry `json:"status"`
+}

--- a/internal/platform/claude.go
+++ b/internal/platform/claude.go
@@ -1,0 +1,67 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/devrimcavusoglu/scribe/internal/skill"
+)
+
+// ClaudeCode is the platform adapter for Claude Code.
+type ClaudeCode struct {
+	homeDir     string
+	projectRoot string
+}
+
+// NewClaudeCode creates a Claude Code adapter.
+// Empty strings use default paths (home directory, current directory).
+func NewClaudeCode(homeDir, projectRoot string) *ClaudeCode {
+	if homeDir == "" {
+		homeDir, _ = os.UserHomeDir()
+	}
+	if projectRoot == "" {
+		projectRoot = "."
+	}
+	return &ClaudeCode{homeDir: homeDir, projectRoot: projectRoot}
+}
+
+// Name implements Platform.
+func (c *ClaudeCode) Name() Type { return TypeClaudeCode }
+
+// Detect implements Platform.
+func (c *ClaudeCode) Detect() bool {
+	_, err := os.Stat(filepath.Join(c.homeDir, ".claude"))
+	return err == nil
+}
+
+// UserSkillsDir implements Platform.
+func (c *ClaudeCode) UserSkillsDir() string {
+	return filepath.Join(c.homeDir, ".claude", "skills")
+}
+
+// ProjectSkillsDir implements Platform.
+func (c *ClaudeCode) ProjectSkillsDir() string {
+	return filepath.Join(c.projectRoot, ".claude", "skills")
+}
+
+// Install implements Platform.
+func (c *ClaudeCode) Install(skillDir string, skillName string, scope skill.Scope) error {
+	return installSkill(skillDir, skillName, c.skillsDir(scope))
+}
+
+// Uninstall implements Platform.
+func (c *ClaudeCode) Uninstall(skillName string, scope skill.Scope) error {
+	return uninstallSkill(skillName, c.skillsDir(scope))
+}
+
+// InstalledSkills implements Platform.
+func (c *ClaudeCode) InstalledSkills(scope skill.Scope) ([]string, error) {
+	return listInstalledSkills(c.skillsDir(scope))
+}
+
+func (c *ClaudeCode) skillsDir(scope skill.Scope) string {
+	if scope == skill.ScopeProject {
+		return c.ProjectSkillsDir()
+	}
+	return c.UserSkillsDir()
+}

--- a/internal/platform/codex.go
+++ b/internal/platform/codex.go
@@ -1,0 +1,72 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/devrimcavusoglu/scribe/internal/skill"
+)
+
+// CodexCLI is the platform adapter for Codex CLI.
+type CodexCLI struct {
+	homeDir     string
+	projectRoot string
+}
+
+// NewCodexCLI creates a Codex CLI adapter.
+// Empty strings use default paths (home directory, current directory).
+func NewCodexCLI(homeDir, projectRoot string) *CodexCLI {
+	if homeDir == "" {
+		homeDir, _ = os.UserHomeDir()
+	}
+	if projectRoot == "" {
+		projectRoot = "."
+	}
+	return &CodexCLI{homeDir: homeDir, projectRoot: projectRoot}
+}
+
+// Name implements Platform.
+func (c *CodexCLI) Name() Type { return TypeCodexCLI }
+
+// Detect implements Platform.
+func (c *CodexCLI) Detect() bool {
+	// Primary: ~/.agents/
+	if _, err := os.Stat(filepath.Join(c.homeDir, ".agents")); err == nil {
+		return true
+	}
+	// Fallback: ~/.codex/
+	_, err := os.Stat(filepath.Join(c.homeDir, ".codex"))
+	return err == nil
+}
+
+// UserSkillsDir implements Platform.
+func (c *CodexCLI) UserSkillsDir() string {
+	return filepath.Join(c.homeDir, ".agents", "skills")
+}
+
+// ProjectSkillsDir implements Platform.
+func (c *CodexCLI) ProjectSkillsDir() string {
+	return filepath.Join(c.projectRoot, ".agents", "skills")
+}
+
+// Install implements Platform.
+func (c *CodexCLI) Install(skillDir string, skillName string, scope skill.Scope) error {
+	return installSkill(skillDir, skillName, c.skillsDir(scope))
+}
+
+// Uninstall implements Platform.
+func (c *CodexCLI) Uninstall(skillName string, scope skill.Scope) error {
+	return uninstallSkill(skillName, c.skillsDir(scope))
+}
+
+// InstalledSkills implements Platform.
+func (c *CodexCLI) InstalledSkills(scope skill.Scope) ([]string, error) {
+	return listInstalledSkills(c.skillsDir(scope))
+}
+
+func (c *CodexCLI) skillsDir(scope skill.Scope) string {
+	if scope == skill.ScopeProject {
+		return c.ProjectSkillsDir()
+	}
+	return c.UserSkillsDir()
+}

--- a/internal/platform/detector.go
+++ b/internal/platform/detector.go
@@ -1,0 +1,74 @@
+package platform
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Detector discovers installed platforms and provides access to adapters.
+type Detector struct {
+	platforms []Platform
+}
+
+// NewDetector creates a Detector initialized with all known platform adapters using real paths.
+func NewDetector() (*Detector, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("determining home directory: %w", err)
+	}
+
+	platforms := []Platform{
+		NewClaudeCode(home, "."),
+		NewCodexCLI(home, "."),
+		NewOpenCode(home, "."),
+	}
+
+	return &Detector{platforms: platforms}, nil
+}
+
+// NewDetectorWithPlatforms creates a Detector with the given platform adapters.
+// Useful for testing with mock platforms.
+func NewDetectorWithPlatforms(platforms []Platform) *Detector {
+	return &Detector{platforms: platforms}
+}
+
+// DetectAll returns only the platforms that are detected as installed.
+func (d *Detector) DetectAll() []Platform {
+	var detected []Platform
+	for _, p := range d.platforms {
+		if p.Detect() {
+			detected = append(detected, p)
+		}
+	}
+	return detected
+}
+
+// Get returns the platform with the given type, or nil if not found.
+func (d *Detector) Get(name Type) Platform {
+	for _, p := range d.platforms {
+		if p.Name() == name {
+			return p
+		}
+	}
+	return nil
+}
+
+// All returns all registered platforms, whether detected or not.
+func (d *Detector) All() []Platform {
+	return d.platforms
+}
+
+// ParsePlatformType validates and returns a platform type from a string flag value.
+// It accepts "all" as a special value.
+func ParsePlatformType(s string) (Type, error) {
+	normalized := strings.ToLower(strings.TrimSpace(s))
+	switch Type(normalized) {
+	case TypeClaudeCode, TypeCodexCLI, TypeOpenCode:
+		return Type(normalized), nil
+	}
+	if normalized == "all" {
+		return Type("all"), nil
+	}
+	return "", fmt.Errorf("unknown platform %q: must be one of claude-code, codex-cli, opencode, or all", s)
+}

--- a/internal/platform/helpers.go
+++ b/internal/platform/helpers.go
@@ -1,0 +1,112 @@
+package platform
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const manifestFile = "SKILL.md"
+
+// installSkill copies a skill directory into the target base directory.
+// It returns an error if the skill already exists at the destination.
+func installSkill(sourceDir, skillName, targetBaseDir string) error {
+	destDir := filepath.Join(targetBaseDir, skillName)
+
+	if _, err := os.Stat(destDir); err == nil {
+		return fmt.Errorf("skill %q already installed at %s", skillName, destDir)
+	}
+
+	if err := os.MkdirAll(targetBaseDir, 0o755); err != nil {
+		return fmt.Errorf("creating skills directory: %w", err)
+	}
+
+	if err := copyDir(sourceDir, destDir); err != nil {
+		// Clean up on failure
+		_ = os.RemoveAll(destDir)
+		return fmt.Errorf("copying skill: %w", err)
+	}
+
+	return nil
+}
+
+// uninstallSkill removes a skill directory from the target base directory.
+func uninstallSkill(skillName, targetBaseDir string) error {
+	destDir := filepath.Join(targetBaseDir, skillName)
+
+	if _, err := os.Stat(destDir); os.IsNotExist(err) {
+		return fmt.Errorf("skill %q not installed at %s", skillName, targetBaseDir)
+	}
+
+	return os.RemoveAll(destDir)
+}
+
+// listInstalledSkills reads directory entries and returns names of valid skill directories.
+func listInstalledSkills(targetBaseDir string) ([]string, error) {
+	entries, err := os.ReadDir(targetBaseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading skills directory: %w", err)
+	}
+
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		// Validate that SKILL.md exists
+		manifestPath := filepath.Join(targetBaseDir, entry.Name(), manifestFile)
+		if _, err := os.Stat(manifestPath); err == nil {
+			names = append(names, entry.Name())
+		}
+	}
+
+	return names, nil
+}
+
+// copyDir recursively copies a directory tree from src to dst.
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+
+		return copyFile(path, target)
+	})
+}
+
+// copyFile copies a single file, preserving permissions.
+func copyFile(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/platform/opencode.go
+++ b/internal/platform/opencode.go
@@ -1,0 +1,67 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/devrimcavusoglu/scribe/internal/skill"
+)
+
+// OpenCode is the platform adapter for OpenCode.
+type OpenCode struct {
+	homeDir     string
+	projectRoot string
+}
+
+// NewOpenCode creates an OpenCode adapter.
+// Empty strings use default paths (home directory, current directory).
+func NewOpenCode(homeDir, projectRoot string) *OpenCode {
+	if homeDir == "" {
+		homeDir, _ = os.UserHomeDir()
+	}
+	if projectRoot == "" {
+		projectRoot = "."
+	}
+	return &OpenCode{homeDir: homeDir, projectRoot: projectRoot}
+}
+
+// Name implements Platform.
+func (o *OpenCode) Name() Type { return TypeOpenCode }
+
+// Detect implements Platform.
+func (o *OpenCode) Detect() bool {
+	_, err := os.Stat(filepath.Join(o.homeDir, ".config", "opencode"))
+	return err == nil
+}
+
+// UserSkillsDir implements Platform.
+func (o *OpenCode) UserSkillsDir() string {
+	return filepath.Join(o.homeDir, ".config", "opencode", "skills")
+}
+
+// ProjectSkillsDir implements Platform.
+func (o *OpenCode) ProjectSkillsDir() string {
+	return filepath.Join(o.projectRoot, ".opencode", "skills")
+}
+
+// Install implements Platform.
+func (o *OpenCode) Install(skillDir string, skillName string, scope skill.Scope) error {
+	return installSkill(skillDir, skillName, o.skillsDir(scope))
+}
+
+// Uninstall implements Platform.
+func (o *OpenCode) Uninstall(skillName string, scope skill.Scope) error {
+	return uninstallSkill(skillName, o.skillsDir(scope))
+}
+
+// InstalledSkills implements Platform.
+func (o *OpenCode) InstalledSkills(scope skill.Scope) ([]string, error) {
+	return listInstalledSkills(o.skillsDir(scope))
+}
+
+func (o *OpenCode) skillsDir(scope skill.Scope) string {
+	if scope == skill.ScopeProject {
+		return o.ProjectSkillsDir()
+	}
+	return o.UserSkillsDir()
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,0 +1,34 @@
+// Package platform provides adapters for installing skills to agentic development platforms.
+package platform
+
+import (
+	"github.com/devrimcavusoglu/scribe/internal/skill"
+)
+
+// Type identifies a supported platform.
+type Type string
+
+// Platform type constants.
+const (
+	TypeClaudeCode Type = "claude-code"
+	TypeCodexCLI   Type = "codex-cli"
+	TypeOpenCode   Type = "opencode"
+)
+
+// Platform defines the interface that each platform adapter must implement.
+type Platform interface {
+	// Name returns the platform type identifier.
+	Name() Type
+	// Detect returns true if this platform is installed on the system.
+	Detect() bool
+	// UserSkillsDir returns the absolute path to the user-level skills directory.
+	UserSkillsDir() string
+	// ProjectSkillsDir returns the absolute path to the project-level skills directory.
+	ProjectSkillsDir() string
+	// Install copies a skill from the registry into the platform's skills directory.
+	Install(skillDir string, skillName string, scope skill.Scope) error
+	// Uninstall removes a skill from the platform's skills directory.
+	Uninstall(skillName string, scope skill.Scope) error
+	// InstalledSkills returns the names of skills installed for the given scope.
+	InstalledSkills(scope skill.Scope) ([]string, error)
+}

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,0 +1,449 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devrimcavusoglu/scribe/internal/skill"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createSkillDir creates a minimal skill directory with a SKILL.md file for testing.
+func createSkillDir(t *testing.T, baseDir, name string) string {
+	t.Helper()
+	dir := filepath.Join(baseDir, name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	content := "---\nname: " + name + "\ndescription: test skill\n---\n\nInstructions here.\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644))
+	return dir
+}
+
+// --- ClaudeCode adapter ---
+
+func TestClaudeCode_Name(t *testing.T) {
+	c := NewClaudeCode("/home/test", "/project")
+	assert.Equal(t, TypeClaudeCode, c.Name())
+}
+
+func TestClaudeCode_Detect_Positive(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
+
+	c := NewClaudeCode(home, t.TempDir())
+	assert.True(t, c.Detect())
+}
+
+func TestClaudeCode_Detect_Negative(t *testing.T) {
+	home := t.TempDir()
+	c := NewClaudeCode(home, t.TempDir())
+	assert.False(t, c.Detect())
+}
+
+func TestClaudeCode_Paths(t *testing.T) {
+	c := NewClaudeCode("/home/test", "/project")
+	assert.Equal(t, filepath.Join("/home/test", ".claude", "skills"), c.UserSkillsDir())
+	assert.Equal(t, filepath.Join("/project", ".claude", "skills"), c.ProjectSkillsDir())
+}
+
+func TestClaudeCode_Install(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	registry := t.TempDir()
+
+	skillDir := createSkillDir(t, registry, "my-skill")
+
+	c := NewClaudeCode(home, project)
+	require.NoError(t, c.Install(skillDir, "my-skill", skill.ScopeUser))
+
+	// Verify installed
+	installed := filepath.Join(home, ".claude", "skills", "my-skill", "SKILL.md")
+	_, err := os.Stat(installed)
+	require.NoError(t, err)
+}
+
+func TestClaudeCode_Install_Duplicate(t *testing.T) {
+	home := t.TempDir()
+	registry := t.TempDir()
+
+	skillDir := createSkillDir(t, registry, "my-skill")
+
+	c := NewClaudeCode(home, t.TempDir())
+	require.NoError(t, c.Install(skillDir, "my-skill", skill.ScopeUser))
+
+	err := c.Install(skillDir, "my-skill", skill.ScopeUser)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "already installed")
+}
+
+func TestClaudeCode_Uninstall(t *testing.T) {
+	home := t.TempDir()
+	registry := t.TempDir()
+
+	skillDir := createSkillDir(t, registry, "my-skill")
+
+	c := NewClaudeCode(home, t.TempDir())
+	require.NoError(t, c.Install(skillDir, "my-skill", skill.ScopeUser))
+	require.NoError(t, c.Uninstall("my-skill", skill.ScopeUser))
+
+	// Verify removed
+	installed := filepath.Join(home, ".claude", "skills", "my-skill")
+	_, err := os.Stat(installed)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestClaudeCode_Uninstall_NotFound(t *testing.T) {
+	home := t.TempDir()
+	c := NewClaudeCode(home, t.TempDir())
+
+	err := c.Uninstall("nonexistent", skill.ScopeUser)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not installed")
+}
+
+func TestClaudeCode_InstalledSkills(t *testing.T) {
+	home := t.TempDir()
+	registry := t.TempDir()
+
+	skillDir1 := createSkillDir(t, registry, "skill-a")
+	skillDir2 := createSkillDir(t, registry, "skill-b")
+
+	c := NewClaudeCode(home, t.TempDir())
+	require.NoError(t, c.Install(skillDir1, "skill-a", skill.ScopeUser))
+	require.NoError(t, c.Install(skillDir2, "skill-b", skill.ScopeUser))
+
+	installed, err := c.InstalledSkills(skill.ScopeUser)
+	require.NoError(t, err)
+	assert.Len(t, installed, 2)
+	assert.Contains(t, installed, "skill-a")
+	assert.Contains(t, installed, "skill-b")
+}
+
+func TestClaudeCode_InstalledSkills_Empty(t *testing.T) {
+	home := t.TempDir()
+	c := NewClaudeCode(home, t.TempDir())
+
+	installed, err := c.InstalledSkills(skill.ScopeUser)
+	require.NoError(t, err)
+	assert.Empty(t, installed)
+}
+
+// --- CodexCLI adapter ---
+
+func TestCodexCLI_Name(t *testing.T) {
+	c := NewCodexCLI("/home/test", "/project")
+	assert.Equal(t, TypeCodexCLI, c.Name())
+}
+
+func TestCodexCLI_Detect_Agents(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".agents"), 0o755))
+
+	c := NewCodexCLI(home, t.TempDir())
+	assert.True(t, c.Detect())
+}
+
+func TestCodexCLI_Detect_CodexFallback(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".codex"), 0o755))
+
+	c := NewCodexCLI(home, t.TempDir())
+	assert.True(t, c.Detect())
+}
+
+func TestCodexCLI_Detect_Negative(t *testing.T) {
+	home := t.TempDir()
+	c := NewCodexCLI(home, t.TempDir())
+	assert.False(t, c.Detect())
+}
+
+func TestCodexCLI_Paths(t *testing.T) {
+	c := NewCodexCLI("/home/test", "/project")
+	assert.Equal(t, filepath.Join("/home/test", ".agents", "skills"), c.UserSkillsDir())
+	assert.Equal(t, filepath.Join("/project", ".agents", "skills"), c.ProjectSkillsDir())
+}
+
+func TestCodexCLI_Install(t *testing.T) {
+	home := t.TempDir()
+	registry := t.TempDir()
+
+	skillDir := createSkillDir(t, registry, "my-skill")
+
+	c := NewCodexCLI(home, t.TempDir())
+	require.NoError(t, c.Install(skillDir, "my-skill", skill.ScopeUser))
+
+	installed := filepath.Join(home, ".agents", "skills", "my-skill", "SKILL.md")
+	_, err := os.Stat(installed)
+	require.NoError(t, err)
+}
+
+func TestCodexCLI_Uninstall(t *testing.T) {
+	home := t.TempDir()
+	registry := t.TempDir()
+
+	skillDir := createSkillDir(t, registry, "my-skill")
+
+	c := NewCodexCLI(home, t.TempDir())
+	require.NoError(t, c.Install(skillDir, "my-skill", skill.ScopeUser))
+	require.NoError(t, c.Uninstall("my-skill", skill.ScopeUser))
+
+	_, err := os.Stat(filepath.Join(home, ".agents", "skills", "my-skill"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+// --- OpenCode adapter ---
+
+func TestOpenCode_Name(t *testing.T) {
+	o := NewOpenCode("/home/test", "/project")
+	assert.Equal(t, TypeOpenCode, o.Name())
+}
+
+func TestOpenCode_Detect_Positive(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "opencode"), 0o755))
+
+	o := NewOpenCode(home, t.TempDir())
+	assert.True(t, o.Detect())
+}
+
+func TestOpenCode_Detect_Negative(t *testing.T) {
+	home := t.TempDir()
+	o := NewOpenCode(home, t.TempDir())
+	assert.False(t, o.Detect())
+}
+
+func TestOpenCode_Paths(t *testing.T) {
+	o := NewOpenCode("/home/test", "/project")
+	assert.Equal(t, filepath.Join("/home/test", ".config", "opencode", "skills"), o.UserSkillsDir())
+	assert.Equal(t, filepath.Join("/project", ".opencode", "skills"), o.ProjectSkillsDir())
+}
+
+func TestOpenCode_Install(t *testing.T) {
+	home := t.TempDir()
+	registry := t.TempDir()
+
+	skillDir := createSkillDir(t, registry, "my-skill")
+
+	o := NewOpenCode(home, t.TempDir())
+	require.NoError(t, o.Install(skillDir, "my-skill", skill.ScopeUser))
+
+	installed := filepath.Join(home, ".config", "opencode", "skills", "my-skill", "SKILL.md")
+	_, err := os.Stat(installed)
+	require.NoError(t, err)
+}
+
+func TestOpenCode_Uninstall(t *testing.T) {
+	home := t.TempDir()
+	registry := t.TempDir()
+
+	skillDir := createSkillDir(t, registry, "my-skill")
+
+	o := NewOpenCode(home, t.TempDir())
+	require.NoError(t, o.Install(skillDir, "my-skill", skill.ScopeUser))
+	require.NoError(t, o.Uninstall("my-skill", skill.ScopeUser))
+
+	_, err := os.Stat(filepath.Join(home, ".config", "opencode", "skills", "my-skill"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+// --- Project scope ---
+
+func TestClaudeCode_ProjectScope(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	registry := t.TempDir()
+
+	skillDir := createSkillDir(t, registry, "proj-skill")
+
+	c := NewClaudeCode(home, project)
+	require.NoError(t, c.Install(skillDir, "proj-skill", skill.ScopeProject))
+
+	installed := filepath.Join(project, ".claude", "skills", "proj-skill", "SKILL.md")
+	_, err := os.Stat(installed)
+	require.NoError(t, err)
+
+	// User scope should be empty
+	userInstalled, err := c.InstalledSkills(skill.ScopeUser)
+	require.NoError(t, err)
+	assert.Empty(t, userInstalled)
+
+	// Project scope should have the skill
+	projectInstalled, err := c.InstalledSkills(skill.ScopeProject)
+	require.NoError(t, err)
+	assert.Len(t, projectInstalled, 1)
+	assert.Equal(t, "proj-skill", projectInstalled[0])
+}
+
+// --- Detector ---
+
+func TestDetector_DetectAll(t *testing.T) {
+	home := t.TempDir()
+
+	// Only create .claude directory
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
+
+	det := NewDetectorWithPlatforms([]Platform{
+		NewClaudeCode(home, t.TempDir()),
+		NewCodexCLI(home, t.TempDir()),
+		NewOpenCode(home, t.TempDir()),
+	})
+
+	detected := det.DetectAll()
+	assert.Len(t, detected, 1)
+	assert.Equal(t, TypeClaudeCode, detected[0].Name())
+}
+
+func TestDetector_Get(t *testing.T) {
+	det := NewDetectorWithPlatforms([]Platform{
+		NewClaudeCode(t.TempDir(), t.TempDir()),
+		NewCodexCLI(t.TempDir(), t.TempDir()),
+	})
+
+	p := det.Get(TypeCodexCLI)
+	require.NotNil(t, p)
+	assert.Equal(t, TypeCodexCLI, p.Name())
+}
+
+func TestDetector_Get_NotFound(t *testing.T) {
+	det := NewDetectorWithPlatforms([]Platform{
+		NewClaudeCode(t.TempDir(), t.TempDir()),
+	})
+
+	p := det.Get(TypeOpenCode)
+	assert.Nil(t, p)
+}
+
+func TestDetector_All(t *testing.T) {
+	det := NewDetectorWithPlatforms([]Platform{
+		NewClaudeCode(t.TempDir(), t.TempDir()),
+		NewCodexCLI(t.TempDir(), t.TempDir()),
+		NewOpenCode(t.TempDir(), t.TempDir()),
+	})
+
+	all := det.All()
+	assert.Len(t, all, 3)
+}
+
+// --- ParsePlatformType ---
+
+func TestParsePlatformType(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    Type
+		wantErr bool
+	}{
+		{"claude-code", TypeClaudeCode, false},
+		{"codex-cli", TypeCodexCLI, false},
+		{"opencode", TypeOpenCode, false},
+		{"all", Type("all"), false},
+		{"Claude-Code", TypeClaudeCode, false},
+		{"ALL", Type("all"), false},
+		{"", "", true},
+		{"unknown", "", true},
+		{"github-copilot", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParsePlatformType(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+// --- Integration: full lifecycle ---
+
+func TestFullLifecycle(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	registry := t.TempDir()
+
+	// Simulate creating a skill in registry
+	skillDir := createSkillDir(t, registry, "lifecycle-skill")
+
+	// Create adapters
+	claude := NewClaudeCode(home, project)
+	codex := NewCodexCLI(home, project)
+
+	// Install to Claude Code
+	require.NoError(t, claude.Install(skillDir, "lifecycle-skill", skill.ScopeUser))
+
+	// Install to Codex CLI
+	require.NoError(t, codex.Install(skillDir, "lifecycle-skill", skill.ScopeUser))
+
+	// List installed on both
+	claudeSkills, err := claude.InstalledSkills(skill.ScopeUser)
+	require.NoError(t, err)
+	assert.Contains(t, claudeSkills, "lifecycle-skill")
+
+	codexSkills, err := codex.InstalledSkills(skill.ScopeUser)
+	require.NoError(t, err)
+	assert.Contains(t, codexSkills, "lifecycle-skill")
+
+	// Uninstall from Claude Code
+	require.NoError(t, claude.Uninstall("lifecycle-skill", skill.ScopeUser))
+
+	claudeSkills, err = claude.InstalledSkills(skill.ScopeUser)
+	require.NoError(t, err)
+	assert.NotContains(t, claudeSkills, "lifecycle-skill")
+
+	// Codex should still have it
+	codexSkills, err = codex.InstalledSkills(skill.ScopeUser)
+	require.NoError(t, err)
+	assert.Contains(t, codexSkills, "lifecycle-skill")
+
+	// Uninstall from Codex
+	require.NoError(t, codex.Uninstall("lifecycle-skill", skill.ScopeUser))
+
+	codexSkills, err = codex.InstalledSkills(skill.ScopeUser)
+	require.NoError(t, err)
+	assert.NotContains(t, codexSkills, "lifecycle-skill")
+}
+
+// --- Helpers ---
+
+func TestCopyDir(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "copy")
+
+	// Create a nested structure
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "file1.txt"), []byte("hello"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "sub", "file2.txt"), []byte("world"), 0o644))
+
+	require.NoError(t, copyDir(src, dst))
+
+	// Verify structure
+	data1, err := os.ReadFile(filepath.Join(dst, "file1.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(data1))
+
+	data2, err := os.ReadFile(filepath.Join(dst, "sub", "file2.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "world", string(data2))
+}
+
+func TestListInstalledSkills_SkipsNonSkillDirs(t *testing.T) {
+	base := t.TempDir()
+
+	// Valid skill dir
+	skillDir := filepath.Join(base, "valid-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("test"), 0o644))
+
+	// Invalid dir (no SKILL.md)
+	require.NoError(t, os.MkdirAll(filepath.Join(base, "not-a-skill"), 0o755))
+
+	// Regular file (should be skipped)
+	require.NoError(t, os.WriteFile(filepath.Join(base, "random.txt"), []byte("test"), 0o644))
+
+	names, err := listInstalledSkills(base)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"valid-skill"}, names)
+}


### PR DESCRIPTION
## Summary

- Add `Platform` interface with adapters for **Claude Code**, **Codex CLI**, and **OpenCode**, enabling cross-platform skill install/uninstall
- Add CLI commands: `skill install`, `skill uninstall`, `platform list`, `platform status`
- Add platform auto-detection, `--platform all` support with partial-failure semantics, and 8 new structured output types

## New commands

| Command | Description |
|---------|-------------|
| `scribe skill install <name> --platform <p>` | Copy skill from registry to platform |
| `scribe skill uninstall <name> --platform <p>` | Remove skill from platform |
| `scribe platform list` | Show detected platforms and paths |
| `scribe platform status [--scope]` | Skill × platform installation matrix |

## Test plan

- [x] 33 platform unit tests (all adapters, detector, helpers, full lifecycle)
- [x] 18 CLI integration tests (install, uninstall, platform list, platform status — JSON + text)
- [x] `go test ./...` passes
- [x] `golangci-lint run` — 0 issues
- [x] `make build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)