### PR TITLE
Add agent setup section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ cd scribe
 make build
 ```
 
+## Agent Setup
+
+After installing scribe, add a line to your project's `AGENTS.md` (or `CLAUDE.md`) so that agents know to use it for skill management:
+
+```sh
+echo 'Use scribe to manage skills. Run `scribe --help` for usage, `scribe skill search <query>` to find existing skills before creating new ones.' >> AGENTS.md
+```
+
+This enables the [tool-forming loop](#features) — agents will search for existing skills before creating new ones, keeping your skill set deduplicated and organized.
+
 ## Quick Start
 
 ```sh


### PR DESCRIPTION
## Summary
- Adds an "Agent Setup" section to README.md between Installation and Quick Start
- Instructs users to add a scribe usage hint to their project's `AGENTS.md` so agents know to use scribe for skill management
- Links to the tool-forming loop feature

Closes #11

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm the `echo` snippet works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)