### PR TITLE
Add scenario 11: autonomous skill creation

### DIFF
--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -10,7 +10,7 @@ Tests how AI agents interact with scribe — discovery, command chaining, JSON p
 ## Workflow
 
 ```sh
-# 1. Set up all 10 scenarios in /tmp
+# 1. Set up all 11 scenarios in /tmp
 make test-manual-setup
 
 # 2. Test each scenario with your agent
@@ -40,6 +40,7 @@ make test-manual-teardown
 | 08 | deduplication-advisory | Agent audits and advises on duplicate skills |
 | 09 | template-skills | Skill creation with `--from-template` |
 | 10 | platform-status-matrix | Fill gaps in skill-platform matrix |
+| 11 | autonomous-skill-creation | Agent autonomously discovers scribe and creates skills from a project need |
 
 ## Directory layout
 

--- a/tests/manual/scenarios/11-autonomous-skill-creation/AGENTS.md
+++ b/tests/manual/scenarios/11-autonomous-skill-creation/AGENTS.md
@@ -1,0 +1,1 @@
+Use `scribe` to manage skills. Run `scribe --help` for usage, `scribe skill recommend <query>` to check for existing skills before creating new ones, and `scribe skill search <query>` to find skills by name. Always use `--json` when parsing output programmatically.

--- a/tests/manual/scenarios/11-autonomous-skill-creation/EXPECTED.md
+++ b/tests/manual/scenarios/11-autonomous-skill-creation/EXPECTED.md
@@ -1,0 +1,35 @@
+# Expected Behavior — Scenario 11
+
+## Pass criteria
+
+- [ ] Agent reads Go source files and identifies formatting/doc-comment inconsistencies
+- [ ] Agent discovers scribe by reading AGENTS.md
+- [ ] Agent **autonomously decides** to create a skill (not told to)
+- [ ] Agent searches or recommends before creating (no duplicates)
+- [ ] Agent creates at least one skill with valid name, description, and meaningful body
+- [ ] Agent validates the created skill(s)
+- [ ] Skill body contains actionable instructions (not just a title)
+
+## Bonus (nice-to-have)
+
+- [ ] Agent installs the skill to claude-code platform
+- [ ] Agent creates multiple complementary skills (e.g., formatting + doc comments)
+- [ ] Agent also fixes the existing Go files (formatting, doc comments)
+- [ ] Agent commits changes or suggests doing so
+
+## Key signal
+
+The agent was never told to "create a skill." The prompt asks about code consistency "going forward" for "any agent working in this repo." A passing agent must bridge the gap from project need to skill creation on its own.
+
+## Verification commands
+
+```sh
+# Skills were created:
+scribe skill list --json
+
+# Skills are valid:
+scribe skill validate <name> --json
+
+# Skill body is non-trivial (more than just frontmatter):
+cat .scribe/skills/<name>/SKILL.md
+```

--- a/tests/manual/scenarios/11-autonomous-skill-creation/PROMPT.md
+++ b/tests/manual/scenarios/11-autonomous-skill-creation/PROMPT.md
@@ -1,0 +1,24 @@
+# Scenario 11: Autonomous Skill Creation
+
+## Pre-populated
+
+- Go project with 3 packages under `pkg/`:
+  - `pkg/auth/auth.go` — Clean formatting, no doc comments
+  - `pkg/handler/handler.go` — Bad formatting: ungrouped imports, missing spaces, inconsistent indentation
+  - `pkg/store/store.go` — Well-formatted, partial doc comments (some functions missing them)
+- Empty scribe registry (initialized but no skills)
+- `.claude/` directory present (platform detection)
+
+## Prompt to give the agent
+
+> We have a Go project with 3 packages (auth, handler, store) and new contributors are joining the team. I want to make sure our Go code stays clean and consistent going forward — proper formatting, doc comments on exported functions, grouped imports, etc. Set things up so that any agent working in this repo can enforce these standards.
+
+## What to observe
+
+1. Does the agent read the Go source files to understand what inconsistencies exist?
+2. Does the agent discover `scribe` by reading AGENTS.md?
+3. Does the agent **autonomously reason** that a reusable skill is the right approach (not just fix the files directly)?
+4. Does it search/recommend before creating to avoid duplicates?
+5. Does it create at least one skill with a valid name, description, and meaningful body?
+6. Does it validate the skill after creation?
+7. Does the agent also fix the existing issues in the Go files, or just create the skill?

--- a/tests/manual/setup.sh
+++ b/tests/manual/setup.sh
@@ -204,6 +204,156 @@ mkdir -p "$DIR/.claude" "$DIR/.agents" "$DIR/.opencode"
 (cd "$DIR" && scribe skill install db-migrate --platform claude-code --scope project --quiet 2>/dev/null || true)
 init_git "$DIR"
 
+# Scenario 11: Autonomous Skill Creation — Go project with inconsistencies, no mention of skills
+echo "Setting up 11-autonomous-skill-creation..."
+DIR="$(setup_scenario 11 autonomous-skill-creation)"
+(cd "$DIR" && scribe init --quiet 2>/dev/null)
+mkdir -p "$DIR/.claude"
+
+# pkg/auth/auth.go — Clean formatting, no doc comments
+mkdir -p "$DIR/pkg/auth"
+cat > "$DIR/pkg/auth/auth.go" <<'GOEOF'
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"time"
+)
+
+var ErrTokenExpired = errors.New("token expired")
+
+type Token struct {
+	Value     string
+	ExpiresAt time.Time
+}
+
+func GenerateToken(ttl time.Duration) (*Token, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return nil, err
+	}
+	return &Token{
+		Value:     hex.EncodeToString(b),
+		ExpiresAt: time.Now().Add(ttl),
+	}, nil
+}
+
+func ValidateToken(t *Token) error {
+	if time.Now().After(t.ExpiresAt) {
+		return ErrTokenExpired
+	}
+	return nil
+}
+
+func RevokeToken(t *Token) {
+	t.ExpiresAt = time.Time{}
+}
+GOEOF
+
+# pkg/handler/handler.go — Bad formatting: ungrouped imports, missing spaces, inconsistent indentation
+mkdir -p "$DIR/pkg/handler"
+cat > "$DIR/pkg/handler/handler.go" <<'GOEOF'
+package handler
+
+import "net/http"
+import "encoding/json"
+import "fmt"
+import "log"
+
+type Response struct {
+    Code int `json:"code"`
+    Message string `json:"message"`
+    Data interface{} `json:"data,omitempty"`
+}
+
+func WriteJSON(w http.ResponseWriter,code int,data interface{}){
+w.Header().Set("Content-Type","application/json")
+w.WriteHeader(code)
+resp:=Response{Code:code,Message:http.StatusText(code),Data:data}
+if err:=json.NewEncoder(w).Encode(resp);err!=nil{
+log.Printf("encode error: %v",err)
+}
+}
+
+func HandleHealth(w http.ResponseWriter,r *http.Request){
+    WriteJSON(w,http.StatusOK,map[string]string{"status":"ok"})
+}
+
+func HandleNotFound(w http.ResponseWriter,r *http.Request){
+WriteJSON(w,http.StatusNotFound,nil)
+}
+
+func HandleError(w http.ResponseWriter,r *http.Request,err error){
+    msg:=fmt.Sprintf("internal error: %v",err)
+log.Println(msg)
+    WriteJSON(w,http.StatusInternalServerError,map[string]string{"error":msg})
+}
+GOEOF
+
+# pkg/store/store.go — Well-formatted, partial doc comments
+mkdir -p "$DIR/pkg/store"
+cat > "$DIR/pkg/store/store.go" <<'GOEOF'
+package store
+
+import (
+	"errors"
+	"sync"
+)
+
+// ErrNotFound is returned when a key does not exist in the store.
+var ErrNotFound = errors.New("key not found")
+
+// Store is a simple thread-safe in-memory key-value store.
+type Store struct {
+	mu   sync.RWMutex
+	data map[string]string
+}
+
+// New creates a new empty Store.
+func New() *Store {
+	return &Store{
+		data: make(map[string]string),
+	}
+}
+
+func (s *Store) Get(key string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.data[key]
+	if !ok {
+		return "", ErrNotFound
+	}
+	return v, nil
+}
+
+// Set stores a key-value pair, overwriting any existing value.
+func (s *Store) Set(key, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = value
+}
+
+func (s *Store) Delete(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+}
+
+func (s *Store) Keys() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	keys := make([]string, 0, len(s.data))
+	for k := range s.data {
+		keys = append(keys, k)
+	}
+	return keys
+}
+GOEOF
+
+init_git "$DIR"
+
 # --- Summary ---
 
 echo ""


### PR DESCRIPTION
## Summary

- Adds manual test scenario 11 (`autonomous-skill-creation`) where the agent must discover scribe on its own from a project-level need
- Includes 3 Go packages with varying code quality (bad formatting, missing doc comments, partial docs)
- Updates `setup.sh` with scenario 11 setup block and `README.md` with the new table row

## Test plan

- [x] `make build && export PATH="$PWD:$PATH" && bash tests/manual/setup.sh` runs cleanly
- [x] `/tmp/scribe-manual-tests/11-autonomous-skill-creation/` created with all expected files
- [x] Go files present under `pkg/auth/`, `pkg/handler/`, `pkg/store/`
- [x] Scribe initialized with empty registry (`scribe skill list --json` returns count 0)
- [x] Ran scenario with an agent — agent autonomously discovered scribe, created and validated a skill

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)