### PR TITLE
Fix install script not executing when piped via curl | bash

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -203,7 +203,9 @@ main() {
     fi
 }
 
-# Guard: only run main when executed directly (not sourced for testing)
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+# Guard: only run main when executed directly or piped (not sourced for testing).
+# When piped (curl | bash), BASH_SOURCE[0] is empty and $0 is "bash".
+# When sourced, BASH_SOURCE[0] is set but differs from $0.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]] || [[ -z "${BASH_SOURCE[0]}" ]]; then
     main
 fi


### PR DESCRIPTION
## Summary

- Fix the `BASH_SOURCE[0] == $0` guard in `scripts/install.sh` that silently prevented `main` from running when piped (`curl ... | bash`). In piped mode, `BASH_SOURCE[0]` is empty and `$0` is `"bash"`, so the condition was always false.
- Add `|| [[ -z "${BASH_SOURCE[0]}" ]]` to handle the piped case while preserving the source-guard for tests.

## Test plan

- [x] All 26 existing install script tests pass (`bash scripts/install_test.sh`)
- [ ] Verify `curl -fsSL .../install.sh | bash` now enters the installer flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)