### PR TITLE
Remove homebrew tap from GoReleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,18 +37,6 @@ changelog:
       - "^test:"
       - "^ci:"
 
-brews:
-  - repository:
-      owner: devrimcavusoglu
-      name: homebrew-tap
-    homepage: "https://github.com/devrimcavusoglu/skern"
-    description: "Agent-first CLI for managing Agent Skills across agentic platforms"
-    license: "Apache-2.0"
-    install: |
-      bin.install "skern"
-    test: |
-      system "#{bin}/skern", "version"
-
 release:
   github:
     owner: devrimcavusoglu


### PR DESCRIPTION
## Summary
- Removed the `brews` section from `.goreleaser.yaml` that was trying to push to a `homebrew-tap` repository, causing release CI to fail
- Installations should use `install.sh` only — no OS-specific package managers (Homebrew, Chocolatey, etc.)

## Test plan
- [ ] Tag a new release and verify the GoReleaser CI completes without errors
- [ ] Verify `install.sh` can still download and install from the GitHub release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)