### PR TITLE
Add CODEOWNERS and docs PR quality checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Default owner for all files
+* @devrimcavusoglu
+
+# Docs and CI ownership
+/docs/ @devrimcavusoglu
+/.github/workflows/ @devrimcavusoglu

--- a/.github/workflows/docs-pr-check.yml
+++ b/.github/workflows/docs-pr-check.yml
@@ -1,0 +1,49 @@
+name: Docs PR Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  docs-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect docs changes
+        id: docs_changes
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          if git diff --name-only "$BASE" "$HEAD" | grep -E '^(docs/|\.github/workflows/docs-pr-check\.yml$)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.docs_changes.outputs.changed == 'true'
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install docs dependencies
+        if: steps.docs_changes.outputs.changed == 'true'
+        run: npm ci
+        working-directory: docs
+
+      - name: Build docs
+        if: steps.docs_changes.outputs.changed == 'true'
+        run: npm run docs:build
+        working-directory: docs
+
+      - name: Check generated links
+        if: steps.docs_changes.outputs.changed == 'true'
+        run: npx --yes linkinator docs/.vitepress/dist --recurse --silent --skip '^https?://' --skip '^mailto:' --skip '^tel:'
+
+      - name: Skip message
+        if: steps.docs_changes.outputs.changed != 'true'
+        run: echo "No docs changes detected; skipping docs build/link checks."


### PR DESCRIPTION
## Summary
- add .github/CODEOWNERS for ownership controls
- add .github/workflows/docs-pr-check.yml to run docs build and link checks on PRs
- make docs checks conditional on docs changes while still reporting status

## Notes
Repository branch/tag protection and rulesets were applied directly via GitHub API in this session.