### PR TITLE
Add --force flag to skill install (#33)

### DIFF
--- a/internal/cli/platform_test.go
+++ b/internal/cli/platform_test.go
@@ -137,6 +137,32 @@ func TestSkillInstall_Duplicate(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestSkillInstall_Force(t *testing.T) {
+	cc, _, _ := testRegistryWithDirs(t)
+	home := t.TempDir()
+	project := t.TempDir()
+	withTestDetector(t, cc, home, project)
+
+	_, err := runCmd(t, cc, "skill", "create", "force-install", "--description", "Test")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, cc, "skill", "install", "force-install", "--platform", "claude-code")
+	require.NoError(t, err)
+
+	// Second install with --force should succeed
+	out, err := runCmd(t, cc, "skill", "install", "force-install", "--platform", "claude-code", "--force", "--json")
+	require.NoError(t, err)
+
+	var result output.SkillInstallResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.True(t, result.Platforms[0].Success)
+
+	// Verify file still exists
+	installed := filepath.Join(home, ".claude", "skills", "force-install", "SKILL.md")
+	_, err = os.Stat(installed)
+	require.NoError(t, err)
+}
+
 func TestSkillInstall_NotFound(t *testing.T) {
 	cc, _, _ := testRegistryWithDirs(t)
 	home := t.TempDir()

--- a/internal/cli/skill_install.go
+++ b/internal/cli/skill_install.go
@@ -14,6 +14,7 @@ func newSkillInstallCmd() *cobra.Command {
 	var (
 		platformFlag string
 		scope        string
+		force        bool
 	)
 
 	cmd := &cobra.Command{
@@ -77,6 +78,11 @@ func newSkillInstallCmd() *cobra.Command {
 				entry := output.PlatformActionEntry{
 					Platform: string(p.Name()),
 				}
+				if force {
+					// Remove existing installation before re-installing; ignore errors
+					// (the skill may not be installed yet).
+					_ = p.Uninstall(name, scopeVal)
+				}
 				if installErr := p.Install(skillDir, name, scopeVal); installErr != nil {
 					entry.Error = installErr.Error()
 				} else {
@@ -104,6 +110,7 @@ func newSkillInstallCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&platformFlag, "platform", "", "target platform (claude-code, codex-cli, opencode, or all)")
 	cmd.Flags().StringVar(&scope, "scope", "user", "skill scope (user or project)")
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite existing installation")
 	_ = cmd.MarkFlagRequired("platform")
 
 	return cmd


### PR DESCRIPTION
## Summary
- Add `--force` flag to `skern skill install` that uninstalls existing installation before reinstalling
- Enables overwriting outdated or corrupt installations without manual uninstall step

## Test plan
- [x] `make lint && make test` passes
- [x] `TestSkillInstall_Force` verifies force reinstall behavior
- [x] Existing install/uninstall tests still pass

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)