### PR TITLE
Surface parse errors in Registry.List() (#34)

### DIFF
--- a/internal/cli/platform_status.go
+++ b/internal/cli/platform_status.go
@@ -33,7 +33,7 @@ func newPlatformStatusCmd() *cobra.Command {
 			}
 
 			// Get skills from registry
-			skills, err := reg.List(scopeVal)
+			skills, _, err := reg.List(scopeVal)
 			if err != nil {
 				return fmt.Errorf("listing skills: %w", err)
 			}

--- a/internal/cli/skill_create.go
+++ b/internal/cli/skill_create.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/devrimcavusoglu/skern/internal/output"
 	"github.com/devrimcavusoglu/skern/internal/overlap"
+	"github.com/devrimcavusoglu/skern/internal/registry"
 	"github.com/devrimcavusoglu/skern/internal/skill"
 	"github.com/spf13/cobra"
 )
@@ -45,7 +46,7 @@ func newSkillCreateCmd() *cobra.Command {
 			}
 
 			// Overlap detection: check existing skills for similarity
-			discovered, err := reg.ListAll()
+			discovered, _, err := reg.ListAll()
 			if err != nil {
 				return fmt.Errorf("checking for overlapping skills: %w", err)
 			}
@@ -143,9 +144,9 @@ const (
 )
 
 func checkSkillCountWarnings(p *output.Printer, reg interface {
-	List(skill.Scope) ([]skill.Skill, error)
+	List(skill.Scope) ([]skill.Skill, []registry.ParseWarning, error)
 }, scope skill.Scope) {
-	skills, err := reg.List(scope)
+	skills, _, err := reg.List(scope)
 	if err != nil {
 		return
 	}

--- a/internal/cli/skill_helpers.go
+++ b/internal/cli/skill_helpers.go
@@ -147,6 +147,16 @@ func formatDedupHints(hints []output.DuplicateHint) string {
 	return b.String()
 }
 
+// formatParseWarnings formats parse warnings for text output.
+func formatParseWarnings(warnings []registry.ParseWarning) string {
+	var b strings.Builder
+	b.WriteString("\nWarning: some skill directories could not be parsed:\n")
+	for _, w := range warnings {
+		fmt.Fprintf(&b, "  - %s: %s\n", w.Name, w.Error)
+	}
+	return b.String()
+}
+
 // formatSearchResults formats search results for text output.
 func formatSearchResults(query string, results []output.SkillResult) string {
 	if len(results) == 0 {

--- a/internal/cli/skill_list.go
+++ b/internal/cli/skill_list.go
@@ -25,9 +25,10 @@ func newSkillListCmd() *cobra.Command {
 			var skillResults []output.SkillResult
 
 			var discovered []registry.DiscoveredSkill
+			var parseWarnings []registry.ParseWarning
 
 			if scope == "all" {
-				discovered, err = reg.ListAll()
+				discovered, parseWarnings, err = reg.ListAll()
 				if err != nil {
 					return err
 				}
@@ -36,10 +37,11 @@ func newSkillListCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				all, err := reg.ListAll()
+				all, pw, err := reg.ListAll()
 				if err != nil {
 					return err
 				}
+				parseWarnings = pw
 				for _, d := range all {
 					if d.Scope == scopeVal {
 						discovered = append(discovered, d)
@@ -75,14 +77,26 @@ func newSkillListCmd() *cobra.Command {
 				}
 			}
 
+			var pwResults []output.ParseWarningResult
+			for _, w := range parseWarnings {
+				pwResults = append(pwResults, output.ParseWarningResult{
+					Name:  w.Name,
+					Error: w.Error,
+				})
+			}
+
 			result := output.SkillListResult{
-				Skills:     skillResults,
-				Count:      len(skillResults),
-				Duplicates: dupHints,
+				Skills:        skillResults,
+				Count:         len(skillResults),
+				Duplicates:    dupHints,
+				ParseWarnings: pwResults,
 			}
 			text := formatSkillTable(skillResults)
 			if len(dupHints) > 0 {
 				text += formatDedupHints(dupHints)
+			}
+			if len(parseWarnings) > 0 {
+				text += formatParseWarnings(parseWarnings)
 			}
 			ctx.Printer.PrintResult(result, text)
 			return nil

--- a/internal/cli/skill_test.go
+++ b/internal/cli/skill_test.go
@@ -470,6 +470,43 @@ func TestSkillList_NoDedupHints(t *testing.T) {
 	assert.Empty(t, result.Duplicates, "should have no duplicate hints for dissimilar skills")
 }
 
+// --- skill list parse warnings ---
+
+func TestSkillList_ParseWarnings_JSON(t *testing.T) {
+	cc, userDir, _ := testRegistryWithDirs(t)
+
+	// Create a valid skill
+	_, err := runCmd(t, cc, "skill", "create", "good-skill", "--description", "Works fine")
+	require.NoError(t, err)
+
+	// Create a corrupt skill directory (no SKILL.md)
+	require.NoError(t, os.MkdirAll(filepath.Join(userDir, "broken-skill"), 0o755))
+
+	out, err := runCmd(t, cc, "skill", "list", "--json")
+	require.NoError(t, err)
+
+	var result output.SkillListResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, 1, result.Count)
+	require.Len(t, result.ParseWarnings, 1)
+	assert.Equal(t, "broken-skill", result.ParseWarnings[0].Name)
+	assert.NotEmpty(t, result.ParseWarnings[0].Error)
+}
+
+func TestSkillList_ParseWarnings_Text(t *testing.T) {
+	cc, userDir, _ := testRegistryWithDirs(t)
+
+	_, err := runCmd(t, cc, "skill", "create", "ok-skill", "--description", "Works fine")
+	require.NoError(t, err)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(userDir, "bad-skill"), 0o755))
+
+	out, err := runCmd(t, cc, "skill", "list")
+	require.NoError(t, err)
+	assert.Contains(t, out, "could not be parsed")
+	assert.Contains(t, out, "bad-skill")
+}
+
 // --- author provenance (modified-by) ---
 
 // --- skill show with files ---

--- a/internal/output/types_skill.go
+++ b/internal/output/types_skill.go
@@ -55,11 +55,18 @@ type DuplicateHint struct {
 	Score  float64 `json:"score"`
 }
 
+// ParseWarningResult records a skill directory that could not be parsed.
+type ParseWarningResult struct {
+	Name  string `json:"name"`
+	Error string `json:"error"`
+}
+
 // SkillListResult is the JSON envelope for skill list output.
 type SkillListResult struct {
-	Skills     []SkillResult   `json:"skills"`
-	Count      int             `json:"count"`
-	Duplicates []DuplicateHint `json:"duplicates,omitempty"`
+	Skills        []SkillResult        `json:"skills"`
+	Count         int                  `json:"count"`
+	Duplicates    []DuplicateHint      `json:"duplicates,omitempty"`
+	ParseWarnings []ParseWarningResult `json:"parse_warnings,omitempty"`
 }
 
 // SkillSearchResult is the JSON envelope for skill search output.

--- a/internal/registry/discovery.go
+++ b/internal/registry/discovery.go
@@ -17,14 +17,16 @@ type DiscoveredSkill struct {
 }
 
 // ListAll returns skills from both user and project scopes.
-func (r *Registry) ListAll() ([]DiscoveredSkill, error) {
+func (r *Registry) ListAll() ([]DiscoveredSkill, []ParseWarning, error) {
 	var result []DiscoveredSkill
+	var allWarnings []ParseWarning
 
 	for _, scope := range []skill.Scope{skill.ScopeUser, skill.ScopeProject} {
-		skills, err := r.List(scope)
+		skills, warnings, err := r.List(scope)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+		allWarnings = append(allWarnings, warnings...)
 		dir := r.scopeDir(scope)
 		for _, s := range skills {
 			result = append(result, DiscoveredSkill{
@@ -35,7 +37,7 @@ func (r *Registry) ListAll() ([]DiscoveredSkill, error) {
 		}
 	}
 
-	return result, nil
+	return result, allWarnings, nil
 }
 
 // ScoredSkill pairs a discovered skill with a relevance score.
@@ -47,7 +49,7 @@ type ScoredSkill struct {
 // FuzzySearch finds skills matching the query using fuzzy name and description similarity.
 // Results are filtered by the given threshold and sorted by score descending.
 func (r *Registry) FuzzySearch(query string, threshold float64) ([]ScoredSkill, error) {
-	all, err := r.ListAll()
+	all, _, err := r.ListAll()
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +77,7 @@ func (r *Registry) FuzzySearch(query string, threshold float64) ([]ScoredSkill, 
 
 // Search finds skills whose names contain the query (case-insensitive).
 func (r *Registry) Search(query string) ([]DiscoveredSkill, error) {
-	all, err := r.ListAll()
+	all, _, err := r.ListAll()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -11,6 +11,12 @@ import (
 
 const manifestFile = "SKILL.md"
 
+// ParseWarning records a skill directory that could not be parsed.
+type ParseWarning struct {
+	Name  string `json:"name"`
+	Error string `json:"error"`
+}
+
 // Registry manages skills stored on the filesystem.
 type Registry struct {
 	userDir    string
@@ -88,34 +94,40 @@ func (r *Registry) Remove(name string, scope skill.Scope) error {
 	return os.RemoveAll(skillDir)
 }
 
-// List returns all skills in the given scope.
-func (r *Registry) List(scope skill.Scope) ([]skill.Skill, error) {
+// List returns all skills in the given scope along with any parse warnings
+// for skill directories that could not be read.
+func (r *Registry) List(scope skill.Scope) ([]skill.Skill, []ParseWarning, error) {
 	dir := r.scopeDir(scope)
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, nil, nil
 		}
-		return nil, fmt.Errorf("reading %s skills directory: %w", scope, err)
+		return nil, nil, fmt.Errorf("reading %s skills directory: %w", scope, err)
 	}
 
 	var skills []skill.Skill
+	var warnings []ParseWarning
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
 
 		manifestPath := filepath.Join(dir, entry.Name(), manifestFile)
-		s, err := skill.ParseManifest(manifestPath)
-		if err != nil {
-			continue // skip invalid entries
+		s, parseErr := skill.ParseManifest(manifestPath)
+		if parseErr != nil {
+			warnings = append(warnings, ParseWarning{
+				Name:  entry.Name(),
+				Error: parseErr.Error(),
+			})
+			continue
 		}
 
 		skills = append(skills, *s)
 	}
 
-	return skills, nil
+	return skills, warnings, nil
 }
 
 // Exists checks whether a skill exists in the given scope.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -101,7 +101,7 @@ func TestRegistry_List(t *testing.T) {
 	_, err = reg.Create(s2, skill.ScopeUser)
 	require.NoError(t, err)
 
-	skills, err := reg.List(skill.ScopeUser)
+	skills, _, err := reg.List(skill.ScopeUser)
 	require.NoError(t, err)
 	assert.Len(t, skills, 2)
 }
@@ -109,7 +109,7 @@ func TestRegistry_List(t *testing.T) {
 func TestRegistry_List_Empty(t *testing.T) {
 	reg := newTestRegistry(t)
 
-	skills, err := reg.List(skill.ScopeUser)
+	skills, _, err := reg.List(skill.ScopeUser)
 	require.NoError(t, err)
 	assert.Empty(t, skills)
 }
@@ -154,7 +154,7 @@ func TestRegistry_ListAll(t *testing.T) {
 	_, err = reg.Create(s2, skill.ScopeProject)
 	require.NoError(t, err)
 
-	all, err := reg.ListAll()
+	all, _, err := reg.ListAll()
 	require.NoError(t, err)
 	assert.Len(t, all, 2)
 
@@ -170,7 +170,7 @@ func TestRegistry_ListAll(t *testing.T) {
 func TestRegistry_ListAll_Empty(t *testing.T) {
 	reg := newTestRegistry(t)
 
-	all, err := reg.ListAll()
+	all, _, err := reg.ListAll()
 	require.NoError(t, err)
 	assert.Empty(t, all)
 }
@@ -234,7 +234,7 @@ func TestRegistry_Search_MultiScope(t *testing.T) {
 	assert.Len(t, results, 2)
 }
 
-func TestRegistry_List_SkipsInvalid(t *testing.T) {
+func TestRegistry_List_SkipsInvalidWithWarning(t *testing.T) {
 	reg := newTestRegistry(t)
 
 	// Create a valid skill
@@ -246,8 +246,13 @@ func TestRegistry_List_SkipsInvalid(t *testing.T) {
 	invalidDir := filepath.Join(reg.userDir, "invalid-dir")
 	require.NoError(t, os.MkdirAll(invalidDir, 0o755))
 
-	skills, err := reg.List(skill.ScopeUser)
+	skills, warnings, err := reg.List(skill.ScopeUser)
 	require.NoError(t, err)
 	assert.Len(t, skills, 1)
 	assert.Equal(t, "valid-skill", skills[0].Name)
+
+	// Should have a parse warning for the invalid directory
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "invalid-dir", warnings[0].Name)
+	assert.NotEmpty(t, warnings[0].Error)
 }


### PR DESCRIPTION
## Summary
- Change `Registry.List()` to return `([]Skill, []ParseWarning, error)` — invalid entries now produce warnings instead of being silently skipped
- Add `ParseWarning` type to registry and `ParseWarningResult` to output types
- Update all callers: `ListAll()`, `FuzzySearch()`, `Search()`, CLI list/create/status commands
- Display parse warnings in `skill list` text output

## Test plan
- [x] `make lint && make test` passes
- [x] `TestRegistry_List_SkipsInvalidWithWarning` verifies warning generation
- [x] All CLI and e2e tests updated for new 3-return signature

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)