### PR TITLE
Add skill tags/categories to frontmatter (#41)

### DIFF
--- a/internal/cli/skill_create.go
+++ b/internal/cli/skill_create.go
@@ -20,6 +20,7 @@ func newSkillCreateCmd() *cobra.Command {
 		scope          string
 		force          bool
 		fromTemplate   string
+		tags           []string
 	)
 
 	cmd := &cobra.Command{
@@ -101,6 +102,7 @@ func newSkillCreateCmd() *cobra.Command {
 			}
 
 			s := skill.NewSkillWithBody(name, description, author, authorType, authorPlatform, body)
+			s.Tags = tags
 
 			// Validate on create (warnings only, don't block)
 			issues := skill.Validate(s)
@@ -132,6 +134,7 @@ func newSkillCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&scope, "scope", "user", "skill scope (user or project)")
 	cmd.Flags().BoolVar(&force, "force", false, "bypass overlap detection block")
 	cmd.Flags().StringVar(&fromTemplate, "from-template", "", "path to a template file for the skill body")
+	cmd.Flags().StringSliceVar(&tags, "tags", nil, "comma-separated tags for the skill")
 
 	return cmd
 }

--- a/internal/cli/skill_helpers.go
+++ b/internal/cli/skill_helpers.go
@@ -61,6 +61,7 @@ func toSkillResult(s *skill.Skill, scope string, path string) output.SkillResult
 			Type:     s.Metadata.Author.Type,
 			Platform: s.Metadata.Author.Platform,
 		},
+		Tags:         s.Tags,
 		Scope:        scope,
 		Path:         path,
 		AllowedTools: s.AllowedTools,
@@ -112,6 +113,9 @@ func formatSkillShow(s output.SkillResult) string {
 	if s.Path != "" {
 		fmt.Fprintf(&b, "Path:        %s\n", s.Path)
 	}
+	if len(s.Tags) > 0 {
+		fmt.Fprintf(&b, "Tags:        %s\n", strings.Join(s.Tags, ", "))
+	}
 	if len(s.AllowedTools) > 0 {
 		fmt.Fprintf(&b, "Tools:       %s\n", strings.Join(s.AllowedTools, ", "))
 	}
@@ -157,6 +161,17 @@ func formatSearchResults(query string, results []output.SkillResult) string {
 	fmt.Fprintf(&b, "Found %d skill(s) matching %q:\n\n", len(results), query)
 	b.WriteString(formatSkillTable(results))
 	return b.String()
+}
+
+// hasTag checks if a tag list contains the given tag (case-insensitive).
+func hasTag(tags []string, tag string) bool {
+	t := strings.ToLower(tag)
+	for _, v := range tags {
+		if strings.ToLower(v) == t {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveSkill finds a skill by name, searching the specified scope or both scopes.

--- a/internal/cli/skill_list.go
+++ b/internal/cli/skill_list.go
@@ -9,7 +9,10 @@ import (
 )
 
 func newSkillListCmd() *cobra.Command {
-	var scope string
+	var (
+		scope string
+		tag   string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -48,6 +51,9 @@ func newSkillListCmd() *cobra.Command {
 			}
 
 			for _, d := range discovered {
+				if tag != "" && !hasTag(d.Skill.Tags, tag) {
+					continue
+				}
 				r := toDiscoveredSkillResult(d)
 				if files, err := skill.ListFiles(d.Path); err == nil && len(files) > 0 {
 					r.Files = files
@@ -90,6 +96,7 @@ func newSkillListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&scope, "scope", "all", "skill scope (user, project, or all)")
+	cmd.Flags().StringVar(&tag, "tag", "", "filter skills by tag")
 
 	return cmd
 }

--- a/internal/cli/skill_search.go
+++ b/internal/cli/skill_search.go
@@ -6,6 +6,8 @@ import (
 )
 
 func newSkillSearchCmd() *cobra.Command {
+	var tag string
+
 	cmd := &cobra.Command{
 		Use:   "search <query>",
 		Short: "Search for skills by name",
@@ -26,6 +28,9 @@ func newSkillSearchCmd() *cobra.Command {
 
 			var skillResults []output.SkillResult
 			for _, d := range discovered {
+				if tag != "" && !hasTag(d.Skill.Tags, tag) {
+					continue
+				}
 				skillResults = append(skillResults, toDiscoveredSkillResult(d))
 			}
 
@@ -39,6 +44,8 @@ func newSkillSearchCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&tag, "tag", "", "filter results by tag")
 
 	return cmd
 }

--- a/internal/cli/skill_test.go
+++ b/internal/cli/skill_test.go
@@ -651,3 +651,89 @@ TODO: Add step-by-step instructions for the agent.
 	assert.Contains(t, out, "claude-code")
 	assert.Contains(t, out, "2025-01-15")
 }
+
+// --- skill tags ---
+
+func TestSkillCreate_WithTags(t *testing.T) {
+	cc := testRegistry(t)
+
+	_, err := runCmd(t, cc, "skill", "create", "tagged-skill",
+		"--description", "A tagged skill",
+		"--tags", "devops,testing",
+		"--json")
+	require.NoError(t, err)
+
+	out, err := runCmd(t, cc, "skill", "show", "tagged-skill", "--json")
+	require.NoError(t, err)
+
+	var result output.SkillResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, []string{"devops", "testing"}, result.Tags)
+}
+
+func TestSkillCreate_WithTags_Show(t *testing.T) {
+	cc := testRegistry(t)
+
+	_, err := runCmd(t, cc, "skill", "create", "tagged-text",
+		"--description", "A tagged skill",
+		"--tags", "ci,deploy")
+	require.NoError(t, err)
+
+	out, err := runCmd(t, cc, "skill", "show", "tagged-text")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Tags:")
+	assert.Contains(t, out, "ci")
+	assert.Contains(t, out, "deploy")
+}
+
+func TestSkillList_FilterByTag(t *testing.T) {
+	cc := testRegistry(t)
+
+	_, err := runCmd(t, cc, "skill", "create", "tool-a",
+		"--description", "Tool A", "--tags", "devops")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, cc, "skill", "create", "tool-b",
+		"--description", "Tool B", "--tags", "testing")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, cc, "skill", "create", "tool-c",
+		"--description", "Tool C", "--tags", "devops,testing")
+	require.NoError(t, err)
+
+	// Filter by devops — should get tool-a and tool-c
+	out, err := runCmd(t, cc, "skill", "list", "--tag", "devops", "--json")
+	require.NoError(t, err)
+
+	var result output.SkillListResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, 2, result.Count)
+
+	names := map[string]bool{}
+	for _, s := range result.Skills {
+		names[s.Name] = true
+	}
+	assert.True(t, names["tool-a"])
+	assert.True(t, names["tool-c"])
+}
+
+func TestSkillSearch_FilterByTag(t *testing.T) {
+	cc := testRegistry(t)
+
+	_, err := runCmd(t, cc, "skill", "create", "code-lint",
+		"--description", "Lint code", "--tags", "code-quality")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, cc, "skill", "create", "code-format",
+		"--description", "Format code", "--tags", "formatting")
+	require.NoError(t, err)
+
+	// Search "code" but filter by code-quality — should get only code-lint
+	out, err := runCmd(t, cc, "skill", "search", "code", "--tag", "code-quality", "--json")
+	require.NoError(t, err)
+
+	var result output.SkillSearchResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, 1, result.Count)
+	assert.Equal(t, "code-lint", result.Results[0].Name)
+}

--- a/internal/output/types_skill.go
+++ b/internal/output/types_skill.go
@@ -34,6 +34,7 @@ type SkillResult struct {
 	Description  string             `json:"description"`
 	Version      string             `json:"version"`
 	Author       AuthorResult       `json:"author"`
+	Tags         []string           `json:"tags,omitempty"`
 	Scope        string             `json:"scope,omitempty"`
 	Path         string             `json:"path,omitempty"`
 	AllowedTools []string           `json:"allowed_tools,omitempty"`

--- a/internal/skill/manifest.go
+++ b/internal/skill/manifest.go
@@ -12,6 +12,7 @@ import (
 type frontmatter struct {
 	Name         string   `yaml:"name"`
 	Description  string   `yaml:"description"`
+	Tags         []string `yaml:"tags,omitempty"`
 	AllowedTools []string `yaml:"allowed-tools,omitempty"`
 	Metadata     Metadata `yaml:"metadata"`
 }
@@ -41,6 +42,7 @@ func ParseManifest(path string) (*Skill, error) {
 	return &Skill{
 		Name:         f.Name,
 		Description:  f.Description,
+		Tags:         f.Tags,
 		AllowedTools: f.AllowedTools,
 		Metadata:     f.Metadata,
 		Body:         body,
@@ -52,6 +54,7 @@ func WriteManifest(s *Skill, path string) error {
 	fm := frontmatter{
 		Name:         s.Name,
 		Description:  s.Description,
+		Tags:         s.Tags,
 		AllowedTools: s.AllowedTools,
 		Metadata:     s.Metadata,
 	}

--- a/internal/skill/manifest_test.go
+++ b/internal/skill/manifest_test.go
@@ -190,3 +190,75 @@ func TestManifest_Roundtrip(t *testing.T) {
 	assert.Equal(t, original.Metadata.ModifiedBy, parsed.Metadata.ModifiedBy)
 	assert.Equal(t, original.Body, parsed.Body)
 }
+
+func TestManifest_Roundtrip_Tags(t *testing.T) {
+	original := &Skill{
+		Name:        "tagged-skill",
+		Description: "A skill with tags.\n",
+		Tags:        []string{"code-review", "testing"},
+		Metadata: Metadata{
+			Author:  Author{Name: "alice", Type: "human"},
+			Version: "0.1.0",
+		},
+		Body: "## Instructions\n\nReview code.\n",
+	}
+
+	path := filepath.Join(t.TempDir(), "SKILL.md")
+	require.NoError(t, WriteManifest(original, path))
+
+	parsed, err := ParseManifest(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Tags, parsed.Tags)
+}
+
+func TestParseManifest_WithTags(t *testing.T) {
+	content := `---
+name: my-skill
+description: A tagged skill.
+tags:
+  - devops
+  - ci-cd
+metadata:
+  author:
+    name: bob
+    type: human
+  version: "0.1.0"
+---
+
+## Instructions
+
+Deploy things.
+`
+
+	path := filepath.Join(t.TempDir(), "SKILL.md")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	s, err := ParseManifest(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"devops", "ci-cd"}, s.Tags)
+}
+
+func TestParseManifest_NoTags(t *testing.T) {
+	content := `---
+name: my-skill
+description: No tags.
+metadata:
+  author:
+    name: bob
+    type: human
+  version: "0.1.0"
+---
+
+Body.
+`
+
+	path := filepath.Join(t.TempDir(), "SKILL.md")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	s, err := ParseManifest(path)
+	require.NoError(t, err)
+
+	assert.Nil(t, s.Tags)
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -44,6 +44,7 @@ type Metadata struct {
 type Skill struct {
 	Name         string   `yaml:"name" json:"name"`
 	Description  string   `yaml:"description" json:"description"`
+	Tags         []string `yaml:"tags,omitempty" json:"tags,omitempty"`
 	AllowedTools []string `yaml:"allowed-tools,omitempty" json:"allowed_tools,omitempty"`
 	Metadata     Metadata `yaml:"metadata" json:"metadata"`
 	Body         string   `yaml:"-" json:"-"`


### PR DESCRIPTION
## Summary
- Add optional `tags` field to `Skill` struct and YAML frontmatter
- Add `--tags` flag to `skill create` for setting tags at creation time
- Add `--tag` filter to `skill list` and `skill search` for filtering by tag
- Display tags in `skill show` output and include in JSON output

## Test plan
- [x] `make lint && make test` passes
- [x] `TestManifest_Roundtrip_Tags`, `TestParseManifest_WithTags`, `TestParseManifest_NoTags` verify manifest parsing
- [x] `TestSkillCreate_WithTags`, `TestSkillCreate_WithTags_Show` verify creation with tags
- [x] `TestSkillList_FilterByTag`, `TestSkillSearch_FilterByTag` verify filtering

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)