### PR TITLE
Add skill edit/update command (#39)

### DIFF
--- a/internal/cli/skill.go
+++ b/internal/cli/skill.go
@@ -12,6 +12,7 @@ func newSkillCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newSkillCreateCmd())
+	cmd.AddCommand(newSkillEditCmd())
 	cmd.AddCommand(newSkillListCmd())
 	cmd.AddCommand(newSkillShowCmd())
 	cmd.AddCommand(newSkillSearchCmd())

--- a/internal/cli/skill_edit.go
+++ b/internal/cli/skill_edit.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/devrimcavusoglu/skern/internal/output"
+	"github.com/devrimcavusoglu/skern/internal/skill"
+	"github.com/spf13/cobra"
+)
+
+func newSkillEditCmd() *cobra.Command {
+	var (
+		scope              string
+		description        string
+		author             string
+		authorType         string
+		authorPlatform     string
+		version            string
+		modifiedByName     string
+		modifiedByType     string
+		modifiedByPlatform string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "edit <name>",
+		Short: "Edit a skill's metadata or body",
+		Long:  "Update skill metadata via flags, or open $EDITOR to edit the SKILL.md file when no flags are provided.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := getContext(cmd)
+			name := args[0]
+
+			reg, err := ctx.NewRegistry()
+			if err != nil {
+				return err
+			}
+
+			s, skillDir, foundScope, err := resolveSkill(reg, name, scope)
+			if err != nil {
+				return err
+			}
+
+			manifestPath := filepath.Join(skillDir, "SKILL.md")
+
+			hasFieldFlags := cmd.Flags().Changed("description") ||
+				cmd.Flags().Changed("author") ||
+				cmd.Flags().Changed("author-type") ||
+				cmd.Flags().Changed("author-platform") ||
+				cmd.Flags().Changed("version")
+
+			if !hasFieldFlags {
+				// Open $EDITOR
+				editor := os.Getenv("EDITOR")
+				if editor == "" {
+					editor = "vi"
+				}
+
+				editorCmd := exec.Command(editor, manifestPath)
+				editorCmd.Stdin = os.Stdin
+				editorCmd.Stdout = os.Stdout
+				editorCmd.Stderr = os.Stderr
+				if err := editorCmd.Run(); err != nil {
+					return fmt.Errorf("editor exited with error: %w", err)
+				}
+
+				// Re-parse the manifest after editing
+				edited, err := skill.ParseManifest(manifestPath)
+				if err != nil {
+					return fmt.Errorf("parsing edited manifest: %w", err)
+				}
+
+				// Append modified-by if requested
+				if modifiedByName != "" {
+					appendModifiedBy(edited, modifiedByName, modifiedByType, modifiedByPlatform)
+					if err := skill.WriteManifest(edited, manifestPath); err != nil {
+						return fmt.Errorf("writing modified-by: %w", err)
+					}
+				}
+
+				result := output.SkillEditResult{
+					Name:    name,
+					Scope:   string(foundScope),
+					Updated: []string{"body"},
+				}
+				text := fmt.Sprintf("Edited skill %q via $EDITOR.\n", name)
+				ctx.Printer.PrintResult(result, text)
+				return nil
+			}
+
+			// Apply field updates
+			var updated []string
+
+			if cmd.Flags().Changed("description") {
+				s.Description = description
+				updated = append(updated, "description")
+			}
+			if cmd.Flags().Changed("author") {
+				s.Metadata.Author.Name = author
+				updated = append(updated, "author.name")
+			}
+			if cmd.Flags().Changed("author-type") {
+				s.Metadata.Author.Type = authorType
+				updated = append(updated, "author.type")
+			}
+			if cmd.Flags().Changed("author-platform") {
+				s.Metadata.Author.Platform = authorPlatform
+				updated = append(updated, "author.platform")
+			}
+			if cmd.Flags().Changed("version") {
+				s.Metadata.Version = version
+				updated = append(updated, "version")
+			}
+
+			// Append modified-by if requested
+			if modifiedByName != "" {
+				appendModifiedBy(s, modifiedByName, modifiedByType, modifiedByPlatform)
+				updated = append(updated, "modified-by")
+			}
+
+			if err := skill.WriteManifest(s, manifestPath); err != nil {
+				return fmt.Errorf("writing manifest: %w", err)
+			}
+
+			result := output.SkillEditResult{
+				Name:    name,
+				Scope:   string(foundScope),
+				Updated: updated,
+			}
+			text := fmt.Sprintf("Updated skill %q: %s\n", name, strings.Join(updated, ", "))
+			ctx.Printer.PrintResult(result, text)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&scope, "scope", "", "skill scope (user or project)")
+	cmd.Flags().StringVar(&description, "description", "", "new description")
+	cmd.Flags().StringVar(&author, "author", "", "new author name")
+	cmd.Flags().StringVar(&authorType, "author-type", "", "new author type (human or agent)")
+	cmd.Flags().StringVar(&authorPlatform, "author-platform", "", "new author platform")
+	cmd.Flags().StringVar(&version, "version", "", "new version")
+	cmd.Flags().StringVar(&modifiedByName, "modified-by", "", "name of the modifier")
+	cmd.Flags().StringVar(&modifiedByType, "modified-by-type", "human", "type of the modifier (human or agent)")
+	cmd.Flags().StringVar(&modifiedByPlatform, "modified-by-platform", "", "platform of the modifier")
+
+	return cmd
+}
+
+func appendModifiedBy(s *skill.Skill, name, typ, platform string) {
+	s.Metadata.ModifiedBy = append(s.Metadata.ModifiedBy, skill.ModifiedByEntry{
+		Name:     name,
+		Type:     typ,
+		Platform: platform,
+		Date:     time.Now().UTC().Format(time.RFC3339),
+	})
+}

--- a/internal/cli/skill_test.go
+++ b/internal/cli/skill_test.go
@@ -651,3 +651,114 @@ TODO: Add step-by-step instructions for the agent.
 	assert.Contains(t, out, "claude-code")
 	assert.Contains(t, out, "2025-01-15")
 }
+
+// --- skill edit ---
+
+func TestSkillEdit_Description(t *testing.T) {
+	cc := testRegistry(t)
+
+	_, err := runCmd(t, cc, "skill", "create", "edit-desc",
+		"--description", "Original description", "--author", "alice")
+	require.NoError(t, err)
+
+	out, err := runCmd(t, cc, "skill", "edit", "edit-desc",
+		"--description", "Updated description", "--json")
+	require.NoError(t, err)
+
+	var result output.SkillEditResult
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	assert.Equal(t, "edit-desc", result.Name)
+	assert.Contains(t, result.Updated, "description")
+
+	// Verify the change persisted
+	showOut, err := runCmd(t, cc, "skill", "show", "edit-desc", "--json")
+	require.NoError(t, err)
+
+	var showResult output.SkillResult
+	require.NoError(t, json.Unmarshal([]byte(showOut), &showResult))
+	assert.Equal(t, "Updated description", showResult.Description)
+}
+
+func TestSkillEdit_Version(t *testing.T) {
+	cc := testRegistry(t)
+
+	_, err := runCmd(t, cc, "skill", "create", "edit-ver",
+		"--description", "A skill", "--author", "alice")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, cc, "skill", "edit", "edit-ver", "--version", "2.0.0")
+	require.NoError(t, err)
+
+	showOut, err := runCmd(t, cc, "skill", "show", "edit-ver", "--json")
+	require.NoError(t, err)
+
+	var showResult output.SkillResult
+	require.NoError(t, json.Unmarshal([]byte(showOut), &showResult))
+	assert.Equal(t, "2.0.0", showResult.Version)
+}
+
+func TestSkillEdit_Author(t *testing.T) {
+	cc := testRegistry(t)
+
+	_, err := runCmd(t, cc, "skill", "create", "edit-auth",
+		"--description", "A skill", "--author", "alice")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, cc, "skill", "edit", "edit-auth",
+		"--author", "bob", "--author-type", "agent", "--author-platform", "claude-code")
+	require.NoError(t, err)
+
+	showOut, err := runCmd(t, cc, "skill", "show", "edit-auth", "--json")
+	require.NoError(t, err)
+
+	var showResult output.SkillResult
+	require.NoError(t, json.Unmarshal([]byte(showOut), &showResult))
+	assert.Equal(t, "bob", showResult.Author.Name)
+	assert.Equal(t, "agent", showResult.Author.Type)
+	assert.Equal(t, "claude-code", showResult.Author.Platform)
+}
+
+func TestSkillEdit_ModifiedBy(t *testing.T) {
+	cc := testRegistry(t)
+
+	_, err := runCmd(t, cc, "skill", "create", "edit-mod",
+		"--description", "A skill", "--author", "alice")
+	require.NoError(t, err)
+
+	_, err = runCmd(t, cc, "skill", "edit", "edit-mod",
+		"--description", "New desc",
+		"--modified-by", "bob", "--modified-by-type", "human")
+	require.NoError(t, err)
+
+	showOut, err := runCmd(t, cc, "skill", "show", "edit-mod", "--json")
+	require.NoError(t, err)
+
+	var showResult output.SkillResult
+	require.NoError(t, json.Unmarshal([]byte(showOut), &showResult))
+	require.Len(t, showResult.ModifiedBy, 1)
+	assert.Equal(t, "bob", showResult.ModifiedBy[0].Name)
+	assert.Equal(t, "human", showResult.ModifiedBy[0].Type)
+	assert.NotEmpty(t, showResult.ModifiedBy[0].Date)
+}
+
+func TestSkillEdit_NotFound(t *testing.T) {
+	cc := testRegistry(t)
+
+	_, err := runCmd(t, cc, "skill", "edit", "nonexistent", "--description", "x")
+	assert.Error(t, err)
+}
+
+func TestSkillEdit_TextOutput(t *testing.T) {
+	cc := testRegistry(t)
+
+	_, err := runCmd(t, cc, "skill", "create", "edit-text",
+		"--description", "A skill", "--author", "alice")
+	require.NoError(t, err)
+
+	out, err := runCmd(t, cc, "skill", "edit", "edit-text",
+		"--description", "Better desc", "--version", "1.0.0")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Updated")
+	assert.Contains(t, out, "description")
+	assert.Contains(t, out, "version")
+}

--- a/internal/cli/skill_test.go
+++ b/internal/cli/skill_test.go
@@ -725,10 +725,16 @@ func TestSkillEdit_ModifiedBy(t *testing.T) {
 		"--description", "A skill", "--author", "alice")
 	require.NoError(t, err)
 
-	_, err = runCmd(t, cc, "skill", "edit", "edit-mod",
+	editOut, err := runCmd(t, cc, "skill", "edit", "edit-mod",
 		"--description", "New desc",
-		"--modified-by", "bob", "--modified-by-type", "human")
+		"--modified-by", "claude", "--modified-by-type", "agent", "--modified-by-platform", "claude-code",
+		"--json")
 	require.NoError(t, err)
+
+	var editResult output.SkillEditResult
+	require.NoError(t, json.Unmarshal([]byte(editOut), &editResult))
+	assert.Contains(t, editResult.Updated, "description")
+	assert.Contains(t, editResult.Updated, "modified-by")
 
 	showOut, err := runCmd(t, cc, "skill", "show", "edit-mod", "--json")
 	require.NoError(t, err)
@@ -736,8 +742,9 @@ func TestSkillEdit_ModifiedBy(t *testing.T) {
 	var showResult output.SkillResult
 	require.NoError(t, json.Unmarshal([]byte(showOut), &showResult))
 	require.Len(t, showResult.ModifiedBy, 1)
-	assert.Equal(t, "bob", showResult.ModifiedBy[0].Name)
-	assert.Equal(t, "human", showResult.ModifiedBy[0].Type)
+	assert.Equal(t, "claude", showResult.ModifiedBy[0].Name)
+	assert.Equal(t, "agent", showResult.ModifiedBy[0].Type)
+	assert.Equal(t, "claude-code", showResult.ModifiedBy[0].Platform)
 	assert.NotEmpty(t, showResult.ModifiedBy[0].Date)
 }
 

--- a/internal/output/types_skill.go
+++ b/internal/output/types_skill.go
@@ -69,6 +69,13 @@ type SkillSearchResult struct {
 	Count   int           `json:"count"`
 }
 
+// SkillEditResult is the JSON envelope for skill edit output.
+type SkillEditResult struct {
+	Name    string   `json:"name"`
+	Scope   string   `json:"scope"`
+	Updated []string `json:"updated"`
+}
+
 // SkillRemoveResult is the JSON envelope for skill remove output.
 type SkillRemoveResult struct {
 	Name  string `json:"name"`


### PR DESCRIPTION
## Summary
- Add `skern skill edit <name>` command completing the CRUD lifecycle
- Support metadata updates via flags: `--description`, `--author`, `--author-type`, `--author-platform`, `--version`
- Open `$EDITOR` for full SKILL.md editing when no field flags are provided
- Support `--modified-by` to append modification tracking entries
- Add `SkillEditResult` output type

## Test plan
- [x] `make lint && make test` passes
- [x] `TestSkillEdit_Description`, `TestSkillEdit_Version`, `TestSkillEdit_Author` verify field updates
- [x] `TestSkillEdit_ModifiedBy` verifies modification tracking
- [x] `TestSkillEdit_NotFound`, `TestSkillEdit_TextOutput` cover error and text output paths

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)