### PR TITLE
Fix false positive warnings from parsing inline code/URLs as file paths (#68)

### DIFF
--- a/internal/skill/folder.go
+++ b/internal/skill/folder.go
@@ -44,6 +44,25 @@ var (
 	mdLinkRe = regexp.MustCompile(`\]\(([^)]+)\)`)
 )
 
+// looksLikeURL reports whether s looks like a URL rather than a file path.
+// It checks for protocol prefixes (http://, https://, ftp://) and domain-like
+// patterns (e.g., example.com/path).
+func looksLikeURL(s string) bool {
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") || strings.HasPrefix(s, "ftp://") {
+		return true
+	}
+	// Check for domain-like pattern: word with dot before the first slash
+	// e.g., "example.com/path", "docs.example.io/guide"
+	slashIdx := strings.Index(s, "/")
+	if slashIdx > 0 {
+		prefix := s[:slashIdx]
+		if strings.Contains(prefix, ".") && !strings.HasPrefix(prefix, ".") && !strings.HasPrefix(prefix, "..") {
+			return true
+		}
+	}
+	return false
+}
+
 // ExtractFileReferences extracts path-like references from a markdown body.
 // It looks for backtick-enclosed paths containing '/' and markdown link targets
 // that are not URLs or anchors.
@@ -53,6 +72,9 @@ func ExtractFileReferences(body string) []string {
 
 	for _, m := range backtickPathRe.FindAllStringSubmatch(body, -1) {
 		p := m[1]
+		if looksLikeURL(p) {
+			continue
+		}
 		if !seen[p] {
 			seen[p] = true
 			refs = append(refs, p)
@@ -61,7 +83,7 @@ func ExtractFileReferences(body string) []string {
 
 	for _, m := range mdLinkRe.FindAllStringSubmatch(body, -1) {
 		p := m[1]
-		if strings.HasPrefix(p, "http") || strings.HasPrefix(p, "#") {
+		if looksLikeURL(p) || strings.HasPrefix(p, "#") {
 			continue
 		}
 		if !seen[p] {

--- a/internal/skill/folder_test.go
+++ b/internal/skill/folder_test.go
@@ -123,12 +123,71 @@ func TestExtractFileReferences(t *testing.T) {
 			body:     "Run `scripts/run.py` or see [script](scripts/run.py).",
 			expected: []string{"scripts/run.py"},
 		},
+		{
+			name:     "backtick URL with protocol skipped",
+			body:     "See `https://example.com/docs/guide` for details.",
+			expected: nil,
+		},
+		{
+			name:     "backtick URL without protocol skipped",
+			body:     "Use `example.com/api/v1` as the endpoint.",
+			expected: nil,
+		},
+		{
+			name:     "backtick domain-like paths skipped",
+			body:     "Check `docs.example.io/guide` and `pkg.go.dev/encoding/json` for reference.",
+			expected: nil,
+		},
+		{
+			name:     "markdown link with domain-like URL skipped",
+			body:     "See [docs](docs.example.com/guide) for more info.",
+			expected: nil,
+		},
+		{
+			name:     "backtick URL mixed with real path",
+			body:     "Use `example.com/api` for the API and `scripts/run.py` for processing.",
+			expected: []string{"scripts/run.py"},
+		},
+		{
+			name:     "relative path with dots not skipped",
+			body:     "Use `./scripts/run.py` and `../lib/utils.py` as helpers.",
+			expected: []string{"./scripts/run.py", "../lib/utils.py"},
+		},
+		{
+			name:     "ftp URL in backtick skipped",
+			body:     "Download from `ftp://files.example.com/data`.",
+			expected: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			refs := ExtractFileReferences(tt.body)
 			assert.Equal(t, tt.expected, refs)
+		})
+	}
+}
+
+func TestLooksLikeURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"https://example.com/path", true},
+		{"http://example.com/path", true},
+		{"ftp://files.example.com/data", true},
+		{"example.com/path", true},
+		{"docs.example.io/guide", true},
+		{"pkg.go.dev/encoding/json", true},
+		{"scripts/run.py", false},
+		{"./scripts/run.py", false},
+		{"../lib/utils.py", false},
+		{"assets/template.json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, looksLikeURL(tt.input))
 		})
 	}
 }
@@ -158,6 +217,12 @@ func TestValidateFolder(t *testing.T) {
 		{
 			name:       "no references",
 			body:       "Simple instructions without file references.",
+			setup:      func(dir string) {},
+			wantIssues: 0,
+		},
+		{
+			name:       "URLs in backticks do not warn",
+			body:       "See `https://example.com/docs` and `example.com/api/v1` for details.",
 			setup:      func(dir string) {},
 			wantIssues: 0,
 		},

--- a/internal/skill/folder_test.go
+++ b/internal/skill/folder_test.go
@@ -183,6 +183,7 @@ func TestLooksLikeURL(t *testing.T) {
 		{"./scripts/run.py", false},
 		{"../lib/utils.py", false},
 		{"assets/template.json", false},
+		{"C://Windows//Users//", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Add `looksLikeURL` helper to detect protocol-prefixed URLs (`http://`, `https://`, `ftp://`) and domain-like patterns (e.g., `example.com/path`, `pkg.go.dev/encoding/json`)
- Apply URL filtering to backtick-enclosed references, which previously had no URL detection
- Unify markdown link URL filtering to use the same `looksLikeURL` helper
- Relative paths (`./`, `../`) are correctly preserved as file references

Closes #68

## Test plan
- [x] Added `TestLooksLikeURL` with 10 cases covering protocols, domains, and real file paths
- [x] Added 7 new `TestExtractFileReferences` cases: backtick URLs with/without protocols, domain-like paths, mixed URLs with real paths, relative dot-paths, FTP URLs
- [x] Added `TestValidateFolder` case verifying URLs in backticks produce no warnings
- [x] All existing tests continue to pass
- [x] `make test` and `make lint` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)