### PR TITLE
Fall back to runtime/debug.ReadBuildInfo for version info (#71)

### DIFF
--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/devrimcavusoglu/skern/internal/output"
 	"github.com/spf13/cobra"
@@ -13,6 +14,38 @@ var (
 	Commit  = "none"
 	Date    = "unknown"
 )
+
+func init() {
+	initVersionFromBuildInfo(debug.ReadBuildInfo)
+}
+
+// initVersionFromBuildInfo populates Version, Commit, and Date from Go build
+// info when ldflags have not been set. The reader parameter allows tests to
+// inject a fake ReadBuildInfo.
+func initVersionFromBuildInfo(reader func() (*debug.BuildInfo, bool)) {
+	if Version != "dev" {
+		return // ldflags already set
+	}
+	info, ok := reader()
+	if !ok {
+		return
+	}
+	if info.Main.Version != "" && info.Main.Version != "(devel)" {
+		Version = info.Main.Version
+	}
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			if s.Value != "" {
+				Commit = s.Value
+			}
+		case "vcs.time":
+			if s.Value != "" {
+				Date = s.Value
+			}
+		}
+	}
+}
 
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"runtime/debug"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,115 @@ func TestVersionCommand_JSON(t *testing.T) {
 
 	err := cmd.Execute()
 	require.NoError(t, err)
+}
+
+func TestInitVersionFromBuildInfo(t *testing.T) {
+	tests := []struct {
+		name            string
+		initialVersion  string
+		buildInfo       *debug.BuildInfo
+		buildInfoOk     bool
+		expectedVersion string
+		expectedCommit  string
+		expectedDate    string
+	}{
+		{
+			name:            "ldflags already set",
+			initialVersion:  "v1.0.0",
+			buildInfo:       &debug.BuildInfo{Main: debug.Module{Version: "v2.0.0"}},
+			buildInfoOk:     true,
+			expectedVersion: "v1.0.0",
+			expectedCommit:  "none",
+			expectedDate:    "unknown",
+		},
+		{
+			name:            "build info unavailable",
+			initialVersion:  "dev",
+			buildInfo:       nil,
+			buildInfoOk:     false,
+			expectedVersion: "dev",
+			expectedCommit:  "none",
+			expectedDate:    "unknown",
+		},
+		{
+			name:           "go install with version and vcs info",
+			initialVersion: "dev",
+			buildInfo: &debug.BuildInfo{
+				Main: debug.Module{Version: "v0.1.1"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "abc123def456"},
+					{Key: "vcs.time", Value: "2026-01-15T10:30:00Z"},
+				},
+			},
+			buildInfoOk:     true,
+			expectedVersion: "v0.1.1",
+			expectedCommit:  "abc123def456",
+			expectedDate:    "2026-01-15T10:30:00Z",
+		},
+		{
+			name:           "devel version is ignored",
+			initialVersion: "dev",
+			buildInfo: &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "abc123"},
+				},
+			},
+			buildInfoOk:     true,
+			expectedVersion: "dev",
+			expectedCommit:  "abc123",
+			expectedDate:    "unknown",
+		},
+		{
+			name:           "version set but no vcs info",
+			initialVersion: "dev",
+			buildInfo: &debug.BuildInfo{
+				Main: debug.Module{Version: "v0.2.0"},
+			},
+			buildInfoOk:     true,
+			expectedVersion: "v0.2.0",
+			expectedCommit:  "none",
+			expectedDate:    "unknown",
+		},
+		{
+			name:           "empty vcs values are ignored",
+			initialVersion: "dev",
+			buildInfo: &debug.BuildInfo{
+				Main: debug.Module{Version: "v0.3.0"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: ""},
+					{Key: "vcs.time", Value: ""},
+				},
+			},
+			buildInfoOk:     true,
+			expectedVersion: "v0.3.0",
+			expectedCommit:  "none",
+			expectedDate:    "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore globals
+			origVersion, origCommit, origDate := Version, Commit, Date
+			t.Cleanup(func() {
+				Version, Commit, Date = origVersion, origCommit, origDate
+			})
+
+			Version = tt.initialVersion
+			Commit = "none"
+			Date = "unknown"
+
+			reader := func() (*debug.BuildInfo, bool) {
+				return tt.buildInfo, tt.buildInfoOk
+			}
+			initVersionFromBuildInfo(reader)
+
+			assert.Equal(t, tt.expectedVersion, Version)
+			assert.Equal(t, tt.expectedCommit, Commit)
+			assert.Equal(t, tt.expectedDate, Date)
+		})
+	}
 }
 
 func TestRootCommand_Help(t *testing.T) {


### PR DESCRIPTION
## Summary

- When `skern` is installed via `go install`, version info is not injected via ldflags, so `skern version` reports `dev (commit: none, built: unknown)`
- Added fallback to `runtime/debug.ReadBuildInfo()` in `internal/cli/version.go` that reads `BuildInfo.Main.Version`, `vcs.revision`, and `vcs.time` when ldflags are not set
- Goreleaser/Makefile builds remain authoritative — the fallback only activates when `Version == "dev"`

## Test plan

- [x] 6 table-driven tests covering: ldflags already set, build info unavailable, full `go install` info, `(devel)` version, version without VCS info, empty VCS values
- [ ] Manual: `go install github.com/devrimcavusoglu/skern/cmd/skern@latest` then `skern version` shows correct version

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)