### PR TITLE
Add Windows to CI matrix (#85)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,13 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Closes #85.

## Summary

- Add `windows-latest` to the `test` job matrix alongside `ubuntu-latest` and `macos-latest`. This catches Windows-specific regressions in the same PR cycle as Linux/macOS, rather than only when a contributor manually runs the build on Windows.
- `fail-fast: false` so a Windows-only flake doesn't cancel the unix runs while we shake out any cross-platform quirks the new matrix entry surfaces.
- `defaults.run.shell: bash` for the `test` job so `make build` and the bash-driven smoke test run consistently on all three OSes — `windows-latest` ships Git Bash so this is free.

## Why

We've been shipping Windows binaries since v0.2.1 (#78) and the project includes a PowerShell installer, but the test matrix was unix-only. Local verification of #81 on Windows surfaced no issues, but a Windows regression in any future change would only get caught post-release. With Windows officially supported, CI should match.

## Verified locally (Windows 11)

- `make build` produces a runnable binary named `skern` (Go's `-o skern` keeps the literal name on Windows)
- `bash scripts/smoke_test.sh ./skern` — 57/57 pass
- The smoke test already has a USERPROFILE/HOME bridge for Git Bash ([scripts/smoke_test.sh:130](scripts/smoke_test.sh#L130)) so no script changes are needed

## Test plan

- [x] CI runs `test` on all three OSes
- [x] `windows-latest` job is green (build + go test + smoke test)
- [x] `lint` job (still ubuntu-only) unaffected