### PR TITLE
Cut v0.3.1: dot-namespaced skill names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 Skern is a minimal, agent-first CLI tool for managing Agent Skills across agentic development platforms (Claude Code, Codex CLI, OpenCode, Cursor, Gemini CLI, GitHub Copilot, Windsurf, Continue, and more). It follows the Agent Skills open standard (agentskills.io) and uses `SKILL.md` files with YAML frontmatter as the canonical format.
 
-The project is written in **Go 1.25+** and the current release is **v0.3.0**.
+The project is written in **Go 1.25+** and the current release is **v0.3.1**.
 
 ## Repository Layout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.3.1] — 2026-05-13
+
+Patch release: widen skill-name validation to accept dot-namespaced names.
+Strict superset of the v0.3.0 regex — every previously valid name remains
+valid, no migration required.
+
 ### Added
 
 - **Dot-namespaced skill names are now valid.** `ValidateName` accepts dots as
@@ -16,9 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regex, no migration required. Enables installers to preserve their
   namespace prefix on platforms that derive slash commands from directory
   names (e.g. GitHub Copilot maps `.copilot/skills/myorg.bootstrap/` to
-  `/myorg.bootstrap`). ([#92])
+  `/myorg.bootstrap`). ([#92], [#93])
 
 [#92]: https://github.com/devrimcavusoglu/skern/issues/92
+[#93]: https://github.com/devrimcavusoglu/skern/pull/93
 
 ## [v0.3.0] — 2026-05-07
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,11 +46,11 @@ Override with the `SKERN_INSTALL_DIR` environment variable.
 ## Pin a specific version
 
 ```sh
-SKERN_VERSION=v0.3.0 curl -fsSL https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.sh | bash
+SKERN_VERSION=v0.3.1 curl -fsSL https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.sh | bash
 ```
 
 ```powershell
-$env:SKERN_VERSION = 'v0.3.0'; irm https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.ps1 | iex
+$env:SKERN_VERSION = 'v0.3.1'; irm https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.ps1 | iex
 ```
 
 ## Build from source

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -33,7 +33,7 @@ Skills should not live inside models. They should live in code. Versioned. Compo
 
 ## What's Shipped
 
-The current release is **v0.3.0**. Major capabilities already in place:
+The current release is **v0.3.1**. Major capabilities already in place:
 
 - Eight platform adapters (Claude Code, Codex CLI, OpenCode, Cursor, Gemini CLI, GitHub Copilot, Windsurf, Continue)
 - Cross-platform binaries for macOS, Linux, and Windows

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -29,11 +29,11 @@ powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.c
 Set `SKERN_VERSION` before running the installer:
 
 ```sh
-SKERN_VERSION=v0.3.0 curl -fsSL https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.sh | bash
+SKERN_VERSION=v0.3.1 curl -fsSL https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.sh | bash
 ```
 
 ```powershell
-$env:SKERN_VERSION = 'v0.3.0'; irm https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.ps1 | iex
+$env:SKERN_VERSION = 'v0.3.1'; irm https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.ps1 | iex
 ```
 
 ## Custom Install Directory


### PR DESCRIPTION
## Summary

Patch release on top of v0.3.0. Stamps CHANGELOG and bumps version refs after [#93](https://github.com/devrimcavusoglu/skern/pull/93) landed dot-namespaced skill names ([#92](https://github.com/devrimcavusoglu/skern/issues/92)).

- `CHANGELOG.md` — move `[Unreleased]` block to `[v0.3.1] — 2026-05-13`
- `AGENTS.md`, `INSTALL.md`, `docs/guide/installation.md`, `docs/guide/index.md` — bump current-release callout and install-pin examples from `v0.3.0` to `v0.3.1`
- Historical M7 milestone entries in `AGENTS.md` left untouched (they describe what shipped in v0.3.0, not v0.3.1)

Strict superset of the v0.3.0 name regex — no breaking change, no migration.

## Test plan

- [ ] CI green on macOS / Linux / Windows
- [ ] Docs PR check green
- [ ] After merge: tag `v0.3.1` on `main` to trigger goreleaser

🤖 Generated with [Claude Code](https://claude.com/claude-code)