### PR TITLE
Make release workflow idempotent on duplicate tag-push deliveries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,15 @@ on:
     tags:
       - "v*"
 
+# Serialize runs for the same tag. GitHub occasionally re-delivers tag-push
+# webhooks, producing two parallel "Release" workflow runs (observed on v0.3.1).
+# Without serialization both runs race on the GitHub release publish step and
+# the loser fails with `422 already_exists` on every asset upload. We do NOT
+# cancel-in-progress because a real release publish must not be interrupted.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -20,7 +29,23 @@ jobs:
         with:
           go-version: "1.25"
 
+      # Idempotency guard: if a release already exists for this tag (i.e. an
+      # earlier run for the same tag already published artifacts), skip
+      # goreleaser instead of trying to re-upload assets and failing with 422.
+      - name: Check whether release already exists
+        id: precheck
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; skipping goreleaser."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run GoReleaser
+        if: steps.precheck.outputs.skip != 'true'
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest


### PR DESCRIPTION
## Summary

Observed during the v0.3.1 cut: a single `git push origin v0.3.1` produced two parallel "Release" workflow runs ([25805331860](https://github.com/devrimcavusoglu/skern/actions/runs/25805331860) and [25805336177](https://github.com/devrimcavusoglu/skern/actions/runs/25805336177)) — webhook re-delivery race. Both goreleaser jobs raced on asset upload; the loser failed with `422 already_exists` on every asset. The release itself was fine, but the failed run is visible noise on the Actions tab.

## Fix

Two changes to `.github/workflows/release.yml`, both required:

1. **Concurrency group** `release-<ref>` with `cancel-in-progress: false` — serializes simultaneous runs for the same tag. Do **not** cancel-in-progress because a real publish must not be interrupted mid-upload.
2. **Pre-flight `gh release view` check** before goreleaser — if a release for the tag already exists, skip goreleaser and let the job exit green. Combined with the concurrency lock, the duplicate run reliably becomes a no-op.

Either change alone is insufficient:
- Serialization without idempotency still hits `422` on the second run.
- Idempotency without serialization races — the release is created ~25s into the first run, after the second run's pre-check would have executed.

## Test plan

- [ ] CI green on this PR (workflow file only — no functional change to skern itself)
- [ ] After merge, next release tag push produces exactly one green Release run (any duplicate webhook becomes a no-op skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)