### PR TITLE
Cut v0.4.0: stamp CHANGELOG, bump version refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ development platforms. It follows the Agent Skills open standard
 ([agentskills.io](https://agentskills.io)) and uses `SKILL.md` files with YAML
 frontmatter as the canonical format.
 
-Written in **Go 1.25+**. Latest release **v0.3.1**; `main` carries unreleased
+Written in **Go 1.25+**. Latest release **v0.4.0**; `main` carries unreleased
 work (see the `[Unreleased]` section of the CHANGELOG).
 
 ### Scope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.4.0] — 2026-08-20
+
+Tag/category group selection across the skill commands, `install.exclude`
+frontmatter for keeping companion files out of platform copies, frontmatter
+pass-through on `SKILL.md` rewrites, and a strict non-interactive contract
+for `skern init`.
+
 ### Added
 
 - **`--category` filter on `skern skill list`.** Filters by namespaced tag
@@ -100,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   directory; the milestone-numbered branch convention was replaced with the
   `<type>/<slug>` scheme actually in use.
 
+[v0.4.0]: https://github.com/devrimcavusoglu/skern/compare/v0.3.1...v0.4.0
 [#90]: https://github.com/devrimcavusoglu/skern/issues/90
 [#95]: https://github.com/devrimcavusoglu/skern/pull/95
 [#96]: https://github.com/devrimcavusoglu/skern/issues/96
@@ -127,6 +135,7 @@ valid, no migration required.
   names (e.g. GitHub Copilot maps `.copilot/skills/myorg.bootstrap/` to
   `/myorg.bootstrap`). ([#92], [#93])
 
+[v0.3.1]: https://github.com/devrimcavusoglu/skern/compare/v0.3.0...v0.3.1
 [#92]: https://github.com/devrimcavusoglu/skern/issues/92
 [#93]: https://github.com/devrimcavusoglu/skern/pull/93
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,11 +46,11 @@ Override with the `SKERN_INSTALL_DIR` environment variable.
 ## Pin a specific version
 
 ```sh
-SKERN_VERSION=v0.3.1 curl -fsSL https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.sh | bash
+SKERN_VERSION=v0.4.0 curl -fsSL https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.sh | bash
 ```
 
 ```powershell
-$env:SKERN_VERSION = 'v0.3.1'; irm https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.ps1 | iex
+$env:SKERN_VERSION = 'v0.4.0'; irm https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.ps1 | iex
 ```
 
 ## Build from source

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -33,14 +33,14 @@ Skills should not live inside models. They should live in code. Versioned. Compo
 
 ## What's Shipped
 
-The current release is **v0.3.1**. Major capabilities already in place:
+The current release is **v0.4.0**. Major capabilities already in place:
 
 - Eight platform adapters (Claude Code, Codex CLI, OpenCode, Cursor, Gemini CLI, GitHub Copilot, Windsurf, Continue)
 - Cross-platform binaries for macOS, Linux, and Windows
 - Skill versioning with semver (`skern skill version --bump major|minor|patch`)
 - `skill diff` and `skill import` (URL / GitHub repo / gist)
 - Stylistic lint hints in `skill validate`
-- Batch install/uninstall and per-platform capacity reporting
+- Batch install/uninstall, tag/category group selection, and per-platform capacity reporting
 
 See the [CHANGELOG](https://github.com/devrimcavusoglu/skern/blob/main/CHANGELOG.md) for full release notes and the project's [GitHub issues](https://github.com/devrimcavusoglu/skern/issues) for the live roadmap (skill sync, dry-run mode, skill dependencies, more import sources, etc.). The roadmap and scope are summarized in [AGENTS.md](https://github.com/devrimcavusoglu/skern/blob/main/AGENTS.md).
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -29,11 +29,11 @@ powershell -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.c
 Set `SKERN_VERSION` before running the installer:
 
 ```sh
-SKERN_VERSION=v0.3.1 curl -fsSL https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.sh | bash
+SKERN_VERSION=v0.4.0 curl -fsSL https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.sh | bash
 ```
 
 ```powershell
-$env:SKERN_VERSION = 'v0.3.1'; irm https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.ps1 | iex
+$env:SKERN_VERSION = 'v0.4.0'; irm https://raw.githubusercontent.com/devrimcavusoglu/skern/main/scripts/install.ps1 | iex
 ```
 
 ## Custom Install Directory


### PR DESCRIPTION
Feature release. Follows the v0.3.1 release procedure (#94): stamp the CHANGELOG, bump version refs, merge, then tag `v0.4.0` on the merge commit to trigger the release workflow.

Highlights going out in v0.4.0:

- `--category` filter on `skern skill list` (#96, #98)
- `--tag` / `--category` group selection on `skill install` / `skill uninstall` (#102)
- `install.exclude` frontmatter to keep companion files out of platform copies (#103)
- Unmodeled frontmatter keys round-trip on every `SKILL.md` rewrite (#100)
- `skern init --no-instructions` + enforced non-interactive contract (#104)
- Docs/agent-guide restructure (#105), idempotent release workflow (#95), CI modernization (#97)

Changes in this PR:

- **CHANGELOG.md** — move the `[Unreleased]` block to `[v0.4.0]` dated 2026-08-20; add the `[v0.4.0]` compare link, plus the `[v0.3.1]` compare link the last release missed
- **AGENTS.md, INSTALL.md, docs/guide/installation.md, docs/guide/index.md** — bump current-release mentions and install-pin examples from v0.3.1 to v0.4.0; mention tag/category group selection in the docs capability list

🤖 Generated with [Claude Code](https://claude.com/claude-code)